### PR TITLE
release: 0.2.2 — command whitelist and per-command completion

### DIFF
--- a/CHANGELOG/0.2.2.md
+++ b/CHANGELOG/0.2.2.md
@@ -1,0 +1,13 @@
+# 0.2.2
+
+Per-command completion improvements. All changes are in the internal completion helper.
+
+## Added
+
+- `makemigrations <TAB>` completes only local apps (`origin == "local"`), filtering out pip packages and Django contrib apps.
+- `showmigrations <TAB>` completes apps that have migrations, local-first — same filtering as `migrate`.
+- `sqlmigrate <app> <TAB>` completes migration names for that app (without `zero` — `sqlmigrate` requires an exact migration name).
+
+## Changed
+
+- Generic fallback replaced with an explicit command whitelist (`_APP_LABEL_COMMANDS`). Commands known to accept app labels (`migrate`, `makemigrations`, `showmigrations`, `sqlmigrate`, `dumpdata`, `test`, `check`) offer app-label completion; all other commands (`runserver`, `shell`, custom commands, etc.) complete options only. This removes the spurious app-label noise from commands that never take app labels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-completion"
-version = "0.2.1"
+version = "0.2.2"
 description = "Shell autocomplete and intelligent suggestions for Django's manage.py"
 readme = "README.md"
 authors = [

--- a/src/django_completion/_complete.py
+++ b/src/django_completion/_complete.py
@@ -4,6 +4,20 @@ import json
 from pathlib import Path
 from typing import Any
 
+# Commands known to accept app labels as positional arguments.
+# Commands not in this set fall back to options-only completion.
+_APP_LABEL_COMMANDS = frozenset(
+    {
+        "check",
+        "dumpdata",
+        "makemigrations",
+        "migrate",
+        "showmigrations",
+        "sqlmigrate",
+        "test",
+    }
+)
+
 
 def _load_cache(path: str) -> dict[str, Any] | None:
     """Read a completion cache from disk, returning None when it is unavailable."""
@@ -71,16 +85,24 @@ def _options(cache: dict[str, Any], cmd: str | None) -> list[str]:
     return [opt for opt in opts if isinstance(opt, str) and opt]
 
 
-def _migration_names(cache: dict[str, Any], app_label: str | None) -> list[str]:
-    """Return cached migration names for an app plus the zero target."""
+def _local_app_labels(cache: dict[str, Any]) -> list[str]:
+    """Return app labels where origin is 'local', alphabetically sorted."""
+    return sorted(label for label, origin in _app_labels(cache) if origin == "local")
+
+
+def _migration_names(cache: dict[str, Any], app_label: str | None, *, include_zero: bool = True) -> list[str]:
+    """Return cached migration names for an app, optionally including the zero target."""
     migrations = cache.get("migrations")
     if not isinstance(app_label, str) or not isinstance(migrations, dict):
-        return ["zero"]
+        return ["zero"] if include_zero else []
 
     names = migrations.get(app_label, [])
     if not isinstance(names, list):
-        return ["zero"]
-    return [name for name in names if isinstance(name, str) and name] + ["zero"]
+        return ["zero"] if include_zero else []
+    result = [name for name in names if isinstance(name, str) and name]
+    if include_zero:
+        result.append("zero")
+    return result
 
 
 def _escape_zsh_description(description: str) -> str:
@@ -123,6 +145,54 @@ def _app_and_option_candidates(cache: dict[str, Any], cmd: str | None) -> list[t
     return candidates
 
 
+def _migration_app_label_candidates(cache: dict[str, Any], fmt: str) -> list[str]:
+    return _format_candidates([(label, f"[{origin}]") for label, origin in _migration_app_labels(cache)], fmt)
+
+
+def _migration_command_candidates(
+    cache: dict[str, Any],
+    cmd: str,
+    pos: int,
+    words: list[str],
+    manage_idx: int,
+    fmt: str,
+) -> list[str]:
+    """Handle migrate / showmigrations / sqlmigrate positional completion."""
+    if pos == 2:
+        return _migration_app_label_candidates(cache, fmt)
+    if pos == 3 and cmd in ("migrate", "sqlmigrate"):
+        app = words[manage_idx + 2] if manage_idx + 2 < len(words) else None
+        include_zero = cmd == "migrate"
+        return _format_candidates([(name, "") for name in _migration_names(cache, app, include_zero=include_zero)], fmt)
+    return _format_candidates(_option_candidates(cache, cmd), fmt)
+
+
+def _positional_candidates(
+    cache: dict[str, Any],
+    cmd: str | None,
+    pos: int,
+    words: list[str],
+    manage_idx: int,
+    fmt: str,
+) -> list[str]:
+    """Return candidates for a non-dash positional argument after the command is known."""
+    if cmd == "autocomplete" and pos == 2:
+        subcommands = [("install", ""), ("refresh", ""), ("status", ""), ("uninstall", "")]
+        return _format_candidates(subcommands, fmt)
+
+    if cmd == "makemigrations":
+        return _format_candidates([(label, "[local]") for label in _local_app_labels(cache)], fmt)
+
+    if cmd in ("migrate", "showmigrations", "sqlmigrate") and isinstance(cmd, str):
+        return _migration_command_candidates(cache, cmd, pos, words, manage_idx, fmt)
+
+    # Whitelist: commands known to accept app labels get app-label + option completion.
+    # Everything else (runserver, shell, custom commands, etc.) gets options only.
+    if cmd in _APP_LABEL_COMMANDS:
+        return _format_candidates(_app_and_option_candidates(cache, cmd), fmt)
+    return _format_candidates(_option_candidates(cache, cmd), fmt)
+
+
 def complete(cache: dict[str, Any], words: list[str], cword: int, fmt: str = "bash") -> list[str]:
     """Return completion candidates for a tokenized manage.py command line."""
     if cword < 0 or cword >= len(words):
@@ -149,22 +219,7 @@ def complete(cache: dict[str, Any], words: list[str], cword: int, fmt: str = "ba
     if cur.startswith("-"):
         return _format_candidates(_option_candidates(cache, cmd), fmt)
 
-    # autocomplete takes subcommands, not app labels.
-    if cmd == "autocomplete" and pos == 2:
-        subcommands = [("install", ""), ("refresh", ""), ("status", ""), ("uninstall", "")]
-        return _format_candidates(subcommands, fmt)
-
-    # migrate is the one v2 command with command-specific positional rules:
-    # first complete only apps that have migrations, then migration names.
-    if cmd == "migrate" and pos == 2:
-        return _format_candidates([(label, f"[{origin}]") for label, origin in _migration_app_labels(cache)], fmt)
-
-    if cmd == "migrate" and pos == 3:
-        app_label = words[manage_idx + 2] if manage_idx + 2 < len(words) else None
-        return _format_candidates([(name, "") for name in _migration_names(cache, app_label)], fmt)
-
-    # Other commands keep the v1 behavior: app labels plus command options.
-    return _format_candidates(_app_and_option_candidates(cache, cmd), fmt)
+    return _positional_candidates(cache, cmd, pos, words, manage_idx, fmt)
 
 
 def _main() -> int:

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -132,15 +132,8 @@ def test_migrate_third_position_dash_completes_options_only():
     ]
 
 
-def test_other_command_completes_all_apps_and_options():
-    assert complete(_cache(), ["manage.py", "shell", ""], 2) == [
-        "accounts",
-        "billing",
-        "auth",
-        "sessions",
-        "--interface",
-        "--command",
-    ]
+def test_unlisted_command_completes_options_only():
+    assert complete(_cache(), ["manage.py", "shell", ""], 2) == ["--interface", "--command"]
 
 
 def test_other_command_dash_completes_options_only():
@@ -153,8 +146,11 @@ def test_v1_cache_preserves_commands_options_and_migrate_app_fallback():
     cache.pop("migrations")
 
     assert complete(cache, ["manage.py", ""], 1) == ["migrate", "runserver", "shell"]
+    # Without a migrations dict, migrate falls back to all app labels.
     assert complete(cache, ["manage.py", "migrate", ""], 2) == ["accounts", "billing", "auth", "sessions"]
     assert complete(cache, ["manage.py", "migrate", "--"], 2) == ["--fake", "--fake-initial", "--database"]
+    # Non-whitelisted commands still return options only (no app labels).
+    assert complete(cache, ["manage.py", "shell", ""], 2) == ["--interface", "--command"]
 
 
 def test_malformed_migrations_falls_back_to_all_app_labels_for_migrate_apps():
@@ -341,3 +337,139 @@ def test_non_string_words_json_cli_prints_nothing(tmp_path):
 
     assert result.returncode == 0
     assert result.stdout == ""
+
+
+# ── 0.2.2-1: Command whitelist ────────────────────────────────────────────────
+
+
+def test_whitelist_runserver_completes_options_only():
+    result = complete(_cache(), ["manage.py", "runserver", ""], 2)
+    assert result == []  # runserver has no options in the fixture
+
+
+def test_whitelist_shell_completes_options_only():
+    result = complete(_cache(), ["manage.py", "shell", ""], 2)
+    assert "accounts" not in result
+    assert "--interface" in result
+
+
+def test_whitelist_custom_command_completes_options_only():
+    result = complete(_cache(), ["manage.py", "mycustomcommand", ""], 2)
+    assert result == []
+
+
+def test_whitelist_dumpdata_completes_app_labels_and_options():
+    cache = _cache()
+    cache["commands"].append("dumpdata")
+    result = complete(cache, ["manage.py", "dumpdata", ""], 2)
+    assert "accounts" in result
+    assert "auth" in result
+
+
+def test_whitelist_test_completes_app_labels_and_options():
+    cache = _cache()
+    cache["commands"].append("test")
+    result = complete(cache, ["manage.py", "test", ""], 2)
+    assert "accounts" in result
+    assert "auth" in result
+
+
+def test_whitelist_check_completes_app_labels_and_options():
+    cache = _cache()
+    cache["commands"].append("check")
+    result = complete(cache, ["manage.py", "check", ""], 2)
+    assert "accounts" in result
+    assert "auth" in result
+
+
+# ── 0.2.2-2: makemigrations ───────────────────────────────────────────────────
+
+
+def test_makemigrations_completes_local_apps_only():
+    result = complete(_cache(), ["manage.py", "makemigrations", ""], 2)
+    assert "accounts" in result
+    assert "billing" in result
+    assert "auth" not in result
+    assert "sessions" not in result
+
+
+def test_makemigrations_dash_completes_options_only():
+    result = complete(_cache(), ["manage.py", "makemigrations", "--"], 2)
+    assert "accounts" not in result
+
+
+def test_makemigrations_local_apps_sorted_alphabetically():
+    cache = _cache()
+    cache["app_labels"] = [
+        {"label": "zoo_app", "origin": "local"},
+        {"label": "accounts", "origin": "local"},
+        {"label": "auth", "origin": "pip"},
+    ]
+    result = complete(cache, ["manage.py", "makemigrations", ""], 2)
+    assert result == ["accounts", "zoo_app"]
+
+
+def test_makemigrations_no_pip_apps_even_with_migrations():
+    cache = _cache()
+    cache["app_labels"] = [
+        {"label": "accounts", "origin": "local"},
+        {"label": "authtoken", "origin": "pip"},
+    ]
+    cache["migrations"]["authtoken"] = ["0001_initial"]
+    result = complete(cache, ["manage.py", "makemigrations", ""], 2)
+    assert "accounts" in result
+    assert "authtoken" not in result
+
+
+# ── 0.2.2-3: showmigrations ───────────────────────────────────────────────────
+
+
+def test_showmigrations_completes_migration_apps_local_first():
+    result = complete(_cache(), ["manage.py", "showmigrations", ""], 2)
+    assert "accounts" in result
+    assert "auth" in result
+    assert result.index("accounts") < result.index("auth")
+
+
+def test_showmigrations_dash_completes_options_only():
+    result = complete(_cache(), ["manage.py", "showmigrations", "--"], 2)
+    assert "accounts" not in result
+
+
+def test_showmigrations_pos3_completes_options_only():
+    result = complete(_cache(), ["manage.py", "showmigrations", "accounts", ""], 3)
+    assert "accounts" not in result
+    assert "0001_initial" not in result
+
+
+# ── 0.2.2-4: sqlmigrate ───────────────────────────────────────────────────────
+
+
+def test_sqlmigrate_completes_migration_apps():
+    result = complete(_cache(), ["manage.py", "sqlmigrate", ""], 2)
+    assert "accounts" in result
+    assert "auth" in result
+
+
+def test_sqlmigrate_dash_at_pos2_completes_options_only():
+    result = complete(_cache(), ["manage.py", "sqlmigrate", "--"], 2)
+    assert "accounts" not in result
+
+
+def test_sqlmigrate_completes_migration_names_without_zero():
+    result = complete(_cache(), ["manage.py", "sqlmigrate", "accounts", ""], 3)
+    assert "0001_initial" in result
+    assert "0002_add_user" in result
+    assert "zero" not in result
+
+
+def test_sqlmigrate_dash_at_pos3_completes_options_only():
+    result = complete(_cache(), ["manage.py", "sqlmigrate", "accounts", "--"], 3)
+    assert "0001_initial" not in result
+    assert "zero" not in result
+
+
+def test_sqlmigrate_pos4_completes_options_only():
+    result = complete(_cache(), ["manage.py", "sqlmigrate", "accounts", "0001_initial", ""], 4)
+    assert "accounts" not in result
+    assert "0001_initial" not in result

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -103,10 +103,10 @@ def test_bash_completes_options(cache_dir):
 
 
 @pytest.mark.skipif(not shutil.which("bash"), reason="bash not available")
-def test_bash_shell_completes_app_labels_and_options(cache_dir):
+def test_bash_runserver_completes_options_only(cache_dir):
     completions = _bash_complete(cache_dir, ["manage.py", "runserver", ""], 2)
-    assert "myapp" in completions
-    assert "auth" in completions
+    assert "myapp" not in completions
+    assert "auth" not in completions
     assert "--noreload" in completions
 
 


### PR DESCRIPTION
## Summary

- Replaced the generic v1 fallback with an explicit `_APP_LABEL_COMMANDS` whitelist. Commands not known to accept app labels (`runserver`, `shell`, custom commands, etc.) now complete **options only** instead of showing every app in the project.
- `makemigrations <TAB>` completes only local apps (`origin == "local"`), filtering out pip packages and Django contrib apps.
- `showmigrations <TAB>` completes apps that have migrations, local-first — same filtering as `migrate` at pos 2.
- `sqlmigrate <app> <TAB>` completes migration names for that app without `zero` (`sqlmigrate` requires an exact migration name).

## Whitelist

Commands that offer app-label completion: `migrate`, `makemigrations`, `showmigrations`, `sqlmigrate`, `dumpdata`, `test`, `check`.

## Test plan

- [ ] `uv run pytest -q` passes (107 passed, 1 skipped)
- [ ] `uv run ruff check .` passes
- [ ] `uv run ty check` passes
- [ ] `uv build` produces a `0.2.2` wheel