### PR TITLE
fix: resolve post-0.2.3 audit gaps (0.2.4)

### DIFF
--- a/CHANGELOG/0.2.4.md
+++ b/CHANGELOG/0.2.4.md
@@ -1,0 +1,13 @@
+# 0.2.4
+
+Bug fixes and test coverage gaps identified in post-0.2.3 audit.
+
+## Fixes
+
+- **zsh template**: `manage.py` token detection now finds the *last* occurrence before the cursor, consistent with the Python helper (`_complete.py`). Previously the zsh template broke on the first match, which could produce a wrong `relative_current` value for contrived inputs like `manage.py shell manage.py <TAB>`.
+- **`_APP_LABEL_COMMANDS`**: Removed `makemigrations` from the whitelist frozenset. `makemigrations` has its own special-case handler that runs before the whitelist check, making its membership there unreachable dead code. No behaviour change.
+
+## Tests
+
+- Added direct unit tests for `_human_age()` covering all boundary cases (seconds, minutes, hours, days) — previously untested despite being required by the 0.2.1-3 acceptance criteria.
+- Added `autocomplete uninstall` tests verifying the reload hint (`source …` / "open a new terminal") and the cache-left-in-place note are always printed — previously the uninstall command had zero test coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-completion"
-version = "0.2.3"
+version = "0.2.4"
 description = "Shell autocomplete and intelligent suggestions for Django's manage.py"
 readme = "README.md"
 authors = [

--- a/src/django_completion/_complete.py
+++ b/src/django_completion/_complete.py
@@ -10,7 +10,6 @@ _APP_LABEL_COMMANDS = frozenset(
     {
         "check",
         "dumpdata",
-        "makemigrations",
         "migrate",
         "showmigrations",
         "sqlmigrate",

--- a/src/django_completion/scripts/zsh_completion.zsh.tmpl
+++ b/src/django_completion/scripts/zsh_completion.zsh.tmpl
@@ -61,7 +61,6 @@ _django_python_manage() {
     for (( i=2; i<CURRENT; i++ )); do
         if [[ "${words[$i]}" == *manage.py ]]; then
             manage_pos=$i
-            break
         fi
     done
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -403,3 +403,85 @@ def test_autocomplete_status_verbose_outputs_diagnostics(tmp_path, settings, iso
     assert "bash script:" in output
     assert "(v0.0.1, outdated)" in output
     assert "Package version:" in output
+
+
+# ── _human_age unit tests ─────────────────────────────────────────────────────
+
+
+from django_completion.management.commands.autocomplete import _human_age  # noqa: E402
+
+
+def test_human_age_seconds():
+    assert _human_age(0) == "0s"
+    assert _human_age(30) == "30s"
+    assert _human_age(59) == "59s"
+
+
+def test_human_age_minutes():
+    assert _human_age(60) == "1 minute"
+    assert _human_age(90) == "1 minute"
+    assert _human_age(120) == "2 minutes"
+    assert _human_age(3599) == "59 minutes"
+
+
+def test_human_age_hours():
+    assert _human_age(3600) == "1 hour"
+    assert _human_age(7200) == "2 hours"
+    assert _human_age(86399) == "23 hours"
+
+
+def test_human_age_days():
+    assert _human_age(86400) == "1 day"
+    assert _human_age(172800) == "2 days"
+    assert _human_age(203692) == "2 days"
+
+
+# ── _uninstall tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+def test_autocomplete_uninstall_prints_reload_hint(tmp_path, settings, isolated_autocomplete_paths):
+    settings.BASE_DIR = str(tmp_path)
+
+    from django.core.management import call_command
+
+    call_command("autocomplete", "install", "--shell", "bash", stdout=io.StringIO(), no_color=True)
+
+    out = io.StringIO()
+    call_command("autocomplete", "uninstall", stdout=out, no_color=True)
+    output = out.getvalue()
+
+    assert "source" in output
+    assert "new terminal" in output
+
+
+@pytest.mark.django_db
+def test_autocomplete_uninstall_prints_cache_note(tmp_path, settings, isolated_autocomplete_paths):
+    settings.BASE_DIR = str(tmp_path)
+
+    from django.core.management import call_command
+
+    call_command("autocomplete", "install", "--shell", "bash", stdout=io.StringIO(), no_color=True)
+
+    out = io.StringIO()
+    call_command("autocomplete", "uninstall", stdout=out, no_color=True)
+    output = out.getvalue()
+
+    assert ".django-completion-cache.json" in output
+    assert "left in place" in output
+
+
+@pytest.mark.django_db
+def test_autocomplete_uninstall_removes_rc_block_and_script(tmp_path, settings, isolated_autocomplete_paths):
+    settings.BASE_DIR = str(tmp_path)
+    _, install_dir, bashrc, _ = isolated_autocomplete_paths
+
+    from django.core.management import call_command
+
+    call_command("autocomplete", "install", "--shell", "bash", stdout=io.StringIO(), no_color=True)
+    assert "django-completion begin" in bashrc.read_text()
+
+    call_command("autocomplete", "uninstall", stdout=io.StringIO(), no_color=True)
+
+    assert "django-completion begin" not in bashrc.read_text()
+    assert not (install_dir / "completion.bash").exists()


### PR DESCRIPTION
## Summary

Post-0.2.3 audit identified four gaps — two missing test suites and two code inconsistencies. This PR resolves all of them and bumps the version to `0.2.4`.

- **Missing `_human_age` unit tests** (Issue 0.2.1-3 acceptance criteria): added direct tests for all boundary cases — seconds, minutes, hours, days.
- **Missing `autocomplete uninstall` tests** (Issue 0.2.1-4 acceptance criteria): added tests verifying the reload hint (`source …` / "open a new terminal") and the cache-left-in-place note. The uninstall command had zero test coverage before.
- **Dead code in `_APP_LABEL_COMMANDS`**: removed `makemigrations` from the frozenset — it has its own special-case handler that runs before the whitelist check, making the whitelist membership unreachable. No behaviour change.
- **Zsh template `manage.py` detection**: removed `break` so the loop finds the *last* `manage.py` token before the cursor, consistent with `_complete.py`'s `_manage_index` logic. The previous first-match behaviour produced a wrong `relative_current` for edge-case inputs.

## Test plan

- [ ] `uv run pytest -q` — 116 passed, 1 skipped
- [ ] `uv run ruff check .` — all checks passed
- [ ] `uv run ty check` — all checks passed