### PR TITLE
chore: improve PyPI and GitHub discoverability (0.2.7)

### DIFF
--- a/CHANGELOG/0.2.7.md
+++ b/CHANGELOG/0.2.7.md
@@ -1,0 +1,11 @@
+# 0.2.7
+
+PyPI metadata and README improvements for discoverability.
+
+## Changes
+
+- **Package description**: rewritten to lead with "tab completion" and name bash/zsh explicitly — matches the search terms people actually use.
+- **Keywords**: expanded from 5 to 14 entries; added `tab-completion`, `bash`, `zsh`, `bash-completion`, `zsh-completion`, `cli`, `developer-tools`, `productivity`, `migration`.
+- **Classifiers**: added `Topic :: Utilities` and `Topic :: Software Development :: Libraries :: Python Modules`.
+- **README**: subheadline updated to include "tab completion", "bash", and "zsh"; fixed broken documentation URL (underscore → hyphen).
+- **GitHub**: repository description, homepage URL, and topics updated to match.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 ![CI](https://github.com/soldatov-ss/django-completion/actions/workflows/ci.yml/badge.svg)
 ![License](https://img.shields.io/pypi/l/django-completion.svg)
 
-Project-aware shell completion for Django's `manage.py`.
+Project-aware **tab completion** for Django's `manage.py`.
 
-Complete commands, app labels, options, and migration targets from your actual Django project.
+Press Tab to complete commands, app labels, options, and migration targets — in bash and zsh — from your actual Django project.
 
 ```bash
 $ python manage.py migrate <TAB>
@@ -148,7 +148,7 @@ Long term, the goal is to learn from real-world usage and explore whether parts 
 
 ## Documentation
 
-Full documentation is at https://soldatov-ss.github.io/django_completion/.
+Full documentation is at https://soldatov-ss.github.io/django-completion/.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-completion"
-version = "0.2.6"
-description = "Shell autocomplete and intelligent suggestions for Django's manage.py"
+version = "0.2.7"
+description = "Tab completion for Django's manage.py — commands, app labels, options, and migration targets in bash and zsh"
 readme = "README.md"
 authors = [
   {name = "Soldatov Serhii", email = "soldatov.own@gmail.com"}
@@ -31,10 +31,16 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Shells",
+    "Topic :: Utilities",
     "Typing :: Typed",
 ]
-keywords = ["autocomplete", "completion", "django", "manage.py", "shell"]
+keywords = [
+    "django", "manage.py", "tab-completion", "autocomplete", "completion",
+    "bash", "zsh", "bash-completion", "zsh-completion", "shell", "cli",
+    "developer-tools", "productivity", "migration",
+]
 license = {text = "MIT"}
 license-files = ["LICENSE"]
 


### PR DESCRIPTION
## Summary

- **Package description** rewritten to lead with "tab completion" and name bash/zsh — matches actual search queries
- **Keywords** expanded from 5 → 14: added `tab-completion`, `bash`, `zsh`, `bash-completion`, `zsh-completion`, `cli`, `developer-tools`, `productivity`, `migration`
- **Classifiers** added: `Topic :: Utilities`, `Topic :: Software Development :: Libraries :: Python Modules`
- **README** subheadline now includes "tab completion", "bash", "zsh"; fixed broken docs URL (`django_completion` → `django-completion`)
- **GitHub repo** description, homepage URL (`https://soldatov-ss.github.io/django-completion/`), and 9 topics applied via `gh repo edit` (already live)

## Why 0.2.7

Metadata-only release. No code changes, no behaviour changes.

## Test plan

- [ ] `uv build` produces a `0.2.7` wheel with updated metadata
- [ ] PyPI project page shows new description and keywords after publish