### PR TITLE
release 0.2.8: refresh delta, _collect_commands, command rule registry, CacheData

### DIFF
--- a/CHANGELOG/0.2.8.md
+++ b/CHANGELOG/0.2.8.md
@@ -1,0 +1,10 @@
+# 0.2.8
+
+UX improvement to `autocomplete refresh` output and three independent architecture refactors.
+
+## Changes
+
+- **`autocomplete refresh` shows count delta and warning summary**: output now includes `(+N)` / `(-N)` suffixes when the command or app count changes versus the previous cache, and a trailing `— N warning(s) (run autocomplete status --verbose for details)` hint when uninspectable commands are present. No delta is shown on a first-ever build or when counts are unchanged.
+- **`_collect_commands()` extracted from `build_cache()`**: command introspection (loading each command class, building argparse parsers, collecting help text and option descriptions) is now a standalone `_collect_commands(commands_map)` function parallel to the existing `_discover_migrations()`. Both collectors return their own `warnings` lists, which `build_cache()` merges. Enables isolated testing of command introspection without triggering migration discovery.
+- **Command rule registry in `_complete.py`**: the `if cmd == ...` routing chain in `_positional_candidates()` is replaced by a declarative `_COMMAND_RULES` dict of `CommandRule` dataclasses. Each entry specifies `pos2` and `pos3` completion slots (`"migration_apps"`, `"local_apps"`, `"all_apps"`, `"migration_names"`, `"migration_names_no_zero"`, `"options"`). Adding a new command-specific completion rule is now a one-line data entry. `_APP_LABEL_COMMANDS` is removed (expressed by `"all_apps"` entries in the registry).
+- **`CacheData` TypedDict**: the v2 cache schema is now expressed as `CacheData` (and `AppLabelEntry`) in `cache.py`. `build_cache()` return type is annotated as `-> CacheData`. `write_cache()` accepts `Mapping[str, Any]` so both `CacheData` and plain dicts remain valid. The `isinstance` guards in `_complete.py` are preserved — they protect against on-disk cache corruption and are unchanged.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,955 @@
+# django-completion — Implementation Plan
+
+## Status
+
+- **v1:** Quiet/internal release candidate. Code is close, but release-facing README, docs, changelog, and final safety polish must be completed before publishing `0.1.0`.
+- **v2:** Public launch release. This is the release to promote on Reddit/LinkedIn and ask real Django developers to install in daily projects.
+- **v3+:** Broader shell/wrapper support and expansion beyond the v2 migration-centered completion model.
+
+This document is the source of truth for product scope, implementation decisions, release gates, and roadmap sequencing.
+
+---
+
+## Product Identity
+
+- **PyPI name:** `django-completion`
+- **Django app label:** `django_completion`
+- **Primary user for the next 3 months:** solo and small-team Django developers who use the terminal daily and run `manage.py` commands often, especially in medium/large projects where app labels, migrations, and command options are hard to remember.
+- **Core promise:** `django-completion` makes `manage.py` feel native in your shell by completing commands, apps, options, and migration targets from your actual Django project.
+- **Launch positioning:** project-aware shell completion for Django's `manage.py`.
+- **Subheadline:** complete commands, app labels, options, and migration targets from your actual Django project.
+- **Primary trust principle:** shell completion should be fast, local, inspectable, reversible, and non-invasive.
+
+---
+
+## Release Strategy
+
+### v1 — Quiet/Internal Release (`0.1.0`)
+
+Goal: publish a credible package to PyPI and GitHub so installation, packaging, and daily internal use can be tested by the maintainer and colleagues before public promotion.
+
+v1 should be polished enough for accidental visitors, but it is not the public launch. It should not look abandoned or placeholder-level.
+
+Release bar:
+
+- README has no TODO placeholders.
+- README explains what works today: command completion, app-label completion, option completion, bash/zsh support.
+- README includes install, setup, status, refresh, uninstall, safety/privacy, limitations, and short roadmap.
+- Docs include installation, usage, how it works, troubleshooting basics, and API reference.
+- Changelog `0.1.0` accurately describes the initial release.
+- `pyproject.toml` metadata is complete.
+- `autocomplete install/status/refresh/uninstall` are documented.
+- Tests, Ruff, type check, and build pass.
+- Wheel includes `py.typed` and shell templates.
+- GitHub/docs links consistently use `django-completion` where the repository URL is intended.
+- Runtime cache is gitignored and not committed.
+- v1 limitations are explicit:
+  - bash and zsh only
+  - requires adding `django_completion` to `INSTALLED_APPS`
+  - no migration-name completion yet
+  - no native Windows/PowerShell support
+  - no `django-admin` support
+
+Recommended v1 safety improvement before quiet release:
+
+- Add `DJANGO_COMPLETION_AUTO_REFRESH = False` setting support.
+- Default remains `True`.
+- When disabled, the `AppConfig` hook should not auto-refresh after commands.
+- `python manage.py autocomplete refresh` should still work manually.
+
+### v2 — Public Launch Release (`0.2.0`)
+
+Goal: the first public, promoted release. Users should see the demo and feel the package is ready to add to real projects now, not merely something to star and revisit later.
+
+Public launch centerpiece:
+
+```bash
+python manage.py migrate <TAB>
+accounts  billing  blog
+
+python manage.py migrate accounts <TAB>
+0001_initial  0002_add_profile  zero
+```
+
+v2 must feel complete for its promise. README, docs, troubleshooting, diagnostics, migration-aware completion, shell parity, and release process are part of the v2 launch scope.
+
+### v3+
+
+Goal: expand compatibility and intelligence after v2 proves daily value.
+
+Likely areas:
+
+- Fish shell support.
+- Broader wrapper support: `poetry run python manage.py`, `pipenv run python manage.py`, etc.
+- Docker integration tests.
+- More command-specific rules.
+- Configurable custom command completion rules.
+- Model-name completion.
+- Settings-module/global-option completion.
+- Private GitHub/package-source classification.
+- Possible Django core proposal once adoption and real-world feedback justify it.
+
+---
+
+## Locked Design Decisions
+
+| # | Area | Decision |
+|---|---|---|
+| 1 | Integration mechanism | Django app added to `INSTALLED_APPS` |
+| 2 | Setup flow | `pip install` or `uv add` -> `INSTALLED_APPS` -> `python manage.py autocomplete install` |
+| 3 | Install location | Keep `~/.local/share/django-completion/completion.bash` and `completion.zsh` |
+| 4 | Shell config | Use marker-delimited source blocks in `.bashrc` / `.zshrc` |
+| 5 | Runtime cache | Project-root `.django-completion-cache.json`, gitignored |
+| 6 | Cache refresh | Auto-refresh after `manage.py` commands, 60-second cooldown, process-local lock |
+| 7 | Manual refresh | `python manage.py autocomplete refresh` always rebuilds |
+| 8 | Auto-refresh setting | Add `DJANGO_COMPLETION_AUTO_REFRESH`, default `True` |
+| 9 | Tab-completion behavior | Shell completion reads only the cache; it must not import Django or rebuild cache |
+| 10 | v1 completion depth | Commands + app labels + option flags |
+| 11 | v2 completion depth | `migrate` app labels + migration names + `zero` |
+| 12 | v2 migration source | Disk-based migration files, not database/applied migration state |
+| 13 | Migration modules | v2 must respect `settings.MIGRATION_MODULES` |
+| 14 | App ordering | Local apps first, then non-local apps |
+| 15 | Shell support v2 | bash and zsh are both first-class |
+| 16 | Shell support v3 | fish |
+| 17 | Python helper | v2 moves completion decision logic into an internal Python helper |
+| 18 | Helper API stability | Internal implementation detail, not public API |
+| 19 | Helper output | Shell-friendly newline-delimited lines; zsh can use `candidate:description` lines |
+| 20 | `django-admin` | Out of scope for v2 |
+| 21 | Wrappers v2 | Support `uv run python manage.py` if straightforward; broader wrappers later |
+| 22 | Path-like manage.py | Support `./manage.py`, `backend/manage.py`, etc. by matching words ending in `manage.py` |
+| 23 | Global options before command | Out of scope for v2 |
+| 24 | Custom wrappers/aliases | Out of scope for v2 |
+| 25 | User-configured completion rules | Out of scope for v2; reserve architecture space |
+| 26 | Telemetry | No telemetry |
+| 27 | Windows | Not officially supported; WSL may work with bash/zsh |
+| 28 | Docker | Docs-only in v2; Docker CI later |
+| 29 | Public roadmap | Concise roadmap in README/docs; detailed implementation here |
+| 30 | Django core path | Long-term, humble, evidence-based; no promise of core inclusion |
+
+---
+
+## Cache Schema
+
+Location: `{project_root}/.django-completion-cache.json`
+
+The cache is generated runtime state and must not be committed.
+
+### v1 Cache Shape
+
+```json
+{
+  "commands": ["migrate", "runserver", "shell"],
+  "app_labels": [
+    {"label": "accounts", "origin": "local"},
+    {"label": "blog", "origin": "local"},
+    {"label": "auth", "origin": "pip"}
+  ],
+  "command_help": {
+    "migrate": "Updates database schema. Manages both apps with migrations and those without."
+  },
+  "command_options": {
+    "migrate": ["--fake", "--fake-initial", "--database", "--run-syncdb", "--check"]
+  },
+  "command_option_descriptions": {
+    "migrate": {
+      "--fake": "Mark migrations as run without actually running them.",
+      "--database": "Nominates a database to synchronize."
+    }
+  },
+  "generated_at": 1714000000.0
+}
+```
+
+### v2 Cache Shape
+
+v2 adds an explicit schema version, migration data, and warning collection.
+
+```json
+{
+  "schema_version": 2,
+  "commands": ["migrate", "runserver", "shell"],
+  "app_labels": [
+    {"label": "accounts", "origin": "local"},
+    {"label": "blog", "origin": "local"},
+    {"label": "auth", "origin": "pip"}
+  ],
+  "command_help": {
+    "migrate": "Updates database schema. Manages both apps with migrations and those without."
+  },
+  "command_options": {
+    "migrate": ["--fake", "--fake-initial", "--database", "--run-syncdb", "--check"]
+  },
+  "command_option_descriptions": {
+    "migrate": {
+      "--fake": "Mark migrations as run without actually running them.",
+      "--database": "Nominates a database to synchronize."
+    }
+  },
+  "migrations": {
+    "accounts": ["0001_initial", "0002_add_profile", "0003_add_avatar"],
+    "blog": ["0001_initial", "0002_add_slug"]
+  },
+  "warnings": [
+    "Could not inspect migrations for app 'legacy': No module named legacy.migrations"
+  ],
+  "generated_at": 1714000000.0
+}
+```
+
+Migration cache rules:
+
+- Keyed by app label.
+- Include only apps that have migrations.
+- Include all migration targets found on disk.
+- Strip `.py` suffix.
+- Exclude `__init__.py`, `__pycache__`, non-Python files, private/hidden files.
+- Sort migration names naturally/alphabetically.
+- Include `zero` in completion output, not necessarily in cache.
+- Respect `settings.MIGRATION_MODULES`:
+  - custom module path -> inspect that module
+  - `None` -> app has no migrations
+  - missing key -> use default app `migrations` package
+- If a migration module cannot be imported or inspected, skip that app and record a warning.
+- Do not check database state in v2.
+- Do not try to determine applied/unapplied migrations in v2.
+
+Cache compatibility rules:
+
+- Missing `schema_version` means v1 cache.
+- v2 shell completion must degrade gracefully if `migrations` is missing.
+- `autocomplete status` should report outdated cache schema.
+- `autocomplete refresh` writes the current schema.
+
+---
+
+## Completion Behavior
+
+### v1 Behavior
+
+Supported invocations:
+
+```bash
+manage.py <TAB>
+python manage.py <TAB>
+python3 manage.py <TAB>
+./manage.py <TAB>
+python ./manage.py <TAB>
+```
+
+Completion rules:
+
+- First argument after `manage.py`: command names.
+- Later arguments:
+  - if current word starts with `-`, complete options only.
+  - otherwise complete app labels plus command options.
+- zsh should show descriptions when available.
+- Missing cache should return no completions silently.
+
+### v2 Behavior
+
+Supported v2 invocation targets:
+
+```bash
+manage.py <TAB>
+./manage.py <TAB>
+backend/manage.py <TAB>
+python manage.py <TAB>
+python3 manage.py <TAB>
+python ./manage.py <TAB>
+uv run python manage.py <TAB>
+uv run python ./manage.py <TAB>
+```
+
+`manage.py` token detection:
+
+- Treat any shell word ending in `manage.py` as the project command marker.
+- Completion context is relative to the word after that token.
+- Do not resolve paths during tab completion.
+
+`migrate` rule:
+
+```bash
+python manage.py migrate <TAB>
+```
+
+- Complete only apps with migrations.
+- Order local apps first, then non-local apps.
+- Include Django contrib and third-party apps if they have migrations.
+
+```bash
+python manage.py migrate accounts <TAB>
+```
+
+- Complete all disk-discovered migration names for `accounts`.
+- Include `zero`.
+- Do not check database state.
+
+```bash
+python manage.py migrate --<TAB>
+```
+
+- Complete options only.
+
+Fallback rule for all other commands:
+
+- Keep v1 behavior: app labels plus options.
+- Do not infer custom management command argument semantics.
+
+Optional v2 stretch:
+
+- `makemigrations <TAB>` local-app filtering if it is trivial after the helper refactor.
+
+Out of v2 scope:
+
+- `django-admin`.
+- Global options before command, e.g. `python manage.py --settings config.settings migrate <TAB>`.
+- Custom aliases like `dj migrate`.
+- Model-name completion.
+- Settings-module completion.
+- User-configured completion rules.
+- Database-aware applied/unapplied migration state.
+
+---
+
+## v2 Internal Completion Helper
+
+v2 should move completion decision logic from inline shell snippets into an internal Python helper.
+
+Motivation:
+
+- Avoid duplicating context logic in bash and zsh templates.
+- Make migration-aware completion testable with normal Python unit tests.
+- Keep shell templates thin.
+- Create a cleaner path to fish and future wrappers.
+
+Suggested module:
+
+```text
+django_completion._complete
+```
+
+The helper is internal. Do not document it as a public API.
+
+Possible CLI contract:
+
+```bash
+python -m django_completion._complete \
+  --cache /path/to/.django-completion-cache.json \
+  --words-json '["python", "manage.py", "migrate", "accounts", ""]' \
+  --cword 4 \
+  --format bash
+```
+
+Output:
+
+- bash mode: newline-delimited plain candidates.
+- zsh mode: newline-delimited candidates, optionally `candidate:description`.
+
+Shell template responsibilities:
+
+- Find nearest `.django-completion-cache.json` by walking upward from `$PWD`.
+- Collect shell words/current index.
+- Call internal Python helper.
+- Render returned candidates with shell-native completion primitives.
+- Stay silent if cache is missing or helper returns nothing.
+
+---
+
+## Management Command Behavior
+
+### `autocomplete install`
+
+v1/v2 behavior:
+
+- Detect shell from `$SHELL`, defaulting to bash if unknown.
+- Support explicit override:
+
+```bash
+python manage.py autocomplete install --shell bash
+python manage.py autocomplete install --shell zsh
+```
+
+- Write managed script to `~/.local/share/django-completion/`.
+- Add marker-delimited source block to shell rc file.
+- Be idempotent.
+- Overwrite the managed script file each time install runs.
+- Build or refresh the cache immediately so completion works after install.
+- Print the next step: restart shell or source the rc file.
+
+v2 addition:
+
+- Embed package/script version in generated shell scripts.
+
+Example:
+
+```sh
+# django-completion version: 0.2.0
+```
+
+### `autocomplete status`
+
+v1 minimum:
+
+- cache path
+- cache found/missing
+- cache age
+- command count
+- app count
+- bash/zsh hook status
+
+v2 default status:
+
+- cache exists/missing
+- cache age
+- schema version current/outdated
+- commands count
+- apps count
+- apps-with-migrations count
+- shell hook installed/missing
+- installed script current/outdated
+- warning count
+
+v2 verbose status:
+
+```bash
+python manage.py autocomplete status --verbose
+```
+
+Verbose output should include:
+
+- cache path
+- schema version
+- generated timestamp
+- command count
+- app count
+- apps with migrations
+- shell script paths
+- installed script versions
+- package version
+- cache warnings
+
+Issue templates should ask users to paste `status --verbose`.
+
+### `autocomplete refresh`
+
+- Force cache rebuild regardless of cooldown.
+- Respect v2 cache schema.
+- Record non-fatal cache build warnings.
+- Continue to work even if `DJANGO_COMPLETION_AUTO_REFRESH = False`.
+
+### `autocomplete uninstall`
+
+Expected behavior:
+
+- Remove marker-delimited shell rc blocks.
+- Delete managed script files:
+  - `~/.local/share/django-completion/completion.bash`
+  - `~/.local/share/django-completion/completion.zsh`
+- Remove the managed install directory if it becomes empty.
+- Never delete files outside the managed path.
+- Never touch user shell config outside the marker block.
+
+---
+
+## Safety, Privacy, and Trust
+
+Must be stated clearly in README and docs:
+
+- No telemetry.
+- No network calls.
+- Shell completion reads only the local cache.
+- Tab completion does not import Django.
+- Tab completion does not touch the database.
+- The cache is local runtime state in the project root.
+- The cache contains command names, app labels, option names/help, migration names, warnings, and timestamps.
+- Shell rc edits are marker-delimited and reversible.
+- `autocomplete uninstall` removes managed shell hooks and managed scripts.
+- The package has no middleware, models, migrations, or request-time behavior.
+- It should be safe if accidentally present in production settings, but docs should recommend development-only installation for teams that prefer strict production settings.
+
+Development-only docs example:
+
+```python
+if DEBUG:
+    INSTALLED_APPS += ["django_completion"]
+```
+
+Also mention that `DEBUG` is not always the right environment switch; teams may prefer separate settings modules or a custom environment flag.
+
+---
+
+## Performance Budgets
+
+Targets:
+
+- Cache build should stay under roughly 1 second for typical small/medium projects.
+- Cached shell completion should feel instant; target under 50 ms.
+- Shell completion must never import Django during tab press.
+- Cache should remain human-readable JSON.
+- Missing or outdated cache should fail quietly in shell completion and be diagnosed through `autocomplete status`.
+
+---
+
+## README and Docs Strategy
+
+### v1 README
+
+Polished but modest. No TODO placeholders.
+
+Must include:
+
+- concise promise
+- what v1 does today
+- install
+- add to `INSTALLED_APPS`
+- run `autocomplete install`
+- status/refresh/uninstall
+- safety/privacy
+- limitations
+- short roadmap to v2
+
+Do not include a misleading v2-style GIF in v1.
+
+### v2 README
+
+Public launch README should lead with proof.
+
+Above-the-fold structure:
+
+```md
+# django-completion
+
+Project-aware shell completion for Django's manage.py.
+
+Complete commands, app labels, options, and migration targets from your actual Django project.
+```
+
+Then show a short terminal demo:
+
+```bash
+$ python manage.py migrate <TAB>
+accounts  billing  blog
+
+$ python manage.py migrate accounts <TAB>
+0001_initial  0002_add_profile  zero
+
+$ python manage.py runserver --<TAB>
+--addrport  --ipv6  --noreload  --nothreading
+```
+
+Installation order:
+
+```bash
+pip install django-completion
+# or
+uv add django-completion
+```
+
+README should include:
+
+- quickstart
+- compatibility matrix
+- why this exists / comparison to Django's built-in command suggestions
+- safety/privacy
+- uninstall
+- troubleshooting link
+- concise public roadmap
+- long-term Django core ambition, phrased humbly
+
+Comparison wording:
+
+```md
+Django can suggest close command names after an error. django-completion prevents many of those errors by completing project-specific commands, app labels, options, and migration targets before you press Enter.
+```
+
+Long-term core wording:
+
+```md
+Long term, the goal is to learn from real-world usage and explore whether parts of this approach could inform Django's own management-command completion story.
+```
+
+### v2 GIF/Demo
+
+Create after v2 behavior is implemented and frozen.
+
+Requirements:
+
+- 10-20 seconds.
+- Dark terminal.
+- Readable font.
+- Minimal prompt/theme distractions.
+- Show exactly:
+  - command completion
+  - app-label completion
+  - migration-name completion
+  - option completion
+- Use a tiny demo Django project with meaningful app names:
+  - `accounts`
+  - `billing`
+  - `blog`
+
+Use it in:
+
+- README top section.
+- docs homepage.
+- Reddit/LinkedIn launch posts.
+
+### Documentation Pages
+
+Required before v2 public launch:
+
+- Installation
+- Quickstart / Usage
+- How it works
+- Troubleshooting
+- Compatibility
+- Safety / Privacy
+- API reference
+- Contributing or architecture notes for adding command-specific rules
+
+How it works must explain:
+
+- installed scripts under `~/.local/share/django-completion/`
+- marker-delimited shell rc source block
+- project-root cache path
+- cache contents
+- auto-refresh after `manage.py` commands
+- manual refresh
+- tab completion reads cache only
+- uninstall cleanup
+- monkey patch / management command execution wrapper
+
+Trust-building monkey patch wording:
+
+```md
+When `django_completion` is in `INSTALLED_APPS`, its AppConfig wraps Django's management command execution so the cache can refresh after commands run. The shell completion scripts do not import Django; they only read the cache file.
+```
+
+Troubleshooting page must cover:
+
+- Tab completion shows nothing.
+- I upgraded but migration completion does not work.
+- Wrong shell was detected.
+- Cache is stale.
+- zsh completions are not showing.
+- I use `uv run python manage.py`.
+- How do I uninstall completely?
+- Will this touch my database?
+- Does this work with Docker?
+
+Docker docs for v2:
+
+- Docs-only, not full support guarantee.
+- Explain likely pattern:
+  - install package inside the Django environment/container
+  - run `python manage.py autocomplete refresh` where Django can import settings
+  - host shell completion can read the cache if the project directory is mounted
+  - shell-hook installation inside ephemeral containers may not be useful
+
+Compatibility matrix:
+
+| Area | Supported in v2 |
+|---|---|
+| Python | 3.10+ |
+| Django | 4.2+ |
+| Shells | bash, zsh |
+| OS | Linux/macOS expected; Windows not officially supported |
+| Windows | WSL may work with bash/zsh |
+| Invocations | `manage.py`, `./manage.py`, `python manage.py`, `python3 manage.py`, `uv run python manage.py` |
+| Completion depth | commands, app labels, options, migrate app labels, migration names |
+
+Do not recommend Homebrew, pipx, or global CLI installation. This is a project-environment Django app.
+
+---
+
+## Testing Strategy
+
+### v1
+
+- Python unit tests for cache/classifier/fuzzy helpers.
+- Shell subprocess tests for bash/zsh script sourcing and basic completion.
+- Integration tests for `autocomplete refresh/status`.
+- Verify:
+  - `uv run pytest -q`
+  - `uv run ruff check .`
+  - `uv run ty check`
+  - `uv build`
+  - wheel contains `py.typed` and shell templates
+
+### v2
+
+Mandatory Python helper tests:
+
+- `manage.py <tab>` -> commands
+- `python manage.py <tab>` -> commands
+- `./manage.py <tab>` -> commands
+- `uv run python manage.py <tab>` -> commands
+- `manage.py migrate <tab>` -> migration app labels
+- `manage.py migrate accounts <tab>` -> migration names + `zero`
+- `manage.py migrate --<tab>` -> options only
+- fallback non-`migrate` command -> app labels + options
+- missing cache -> empty completions
+- v1 cache missing `schema_version` -> graceful fallback / outdated status
+- `MIGRATION_MODULES` custom module
+- `MIGRATION_MODULES["app"] = None`
+- warning collection for uninspectable migrations
+
+Shell subprocess tests should become thinner:
+
+- bash script registers and calls helper correctly
+- zsh script sources successfully and calls helper correctly
+- cache-missing behavior is silent
+- path-like `./manage.py` works in bash if practical
+
+CI scope for v2:
+
+- Linux bash/zsh CI.
+- macOS later if users report issues.
+- Docker integration tests later, not v2.
+
+Manual v2 release checks:
+
+- install/uninstall manually tested in bash
+- install/uninstall manually tested in zsh
+- upgrade path from v1 script to v2 script checked
+- `autocomplete status --verbose` output checked
+- demo project completion checked before recording GIF
+
+---
+
+## GitHub and Community Setup
+
+Before v2 public launch:
+
+- Enable GitHub Discussions.
+- Keep Issues for actionable work.
+- Use Discussions for support, exploratory feedback, and ideas.
+
+Discussion categories:
+
+- Announcements
+- Q&A
+- Ideas
+- Show and tell
+
+Issue templates:
+
+- Bug report
+- Completion missing/wrong
+- Feature request
+- Shell/environment issue
+
+Issue templates should ask for:
+
+- OS
+- shell
+- Python version
+- Django version
+- install method
+- invocation style (`python manage.py`, `uv run python manage.py`, etc.)
+- relevant command line
+- `python manage.py autocomplete status --verbose`
+
+No telemetry.
+
+Adoption signals:
+
+- PyPI downloads
+- GitHub stars
+- Issues/Discussions quality
+- Reddit/LinkedIn feedback
+- users reporting real project usage
+
+Do not use stars alone to choose product direction.
+
+---
+
+## Launch and Maintenance Strategy
+
+### Public Launch Timing
+
+Do not publicly promote v1.
+
+Promote v2 only after:
+
+- migration-aware completion works
+- README/docs are launch-ready
+- troubleshooting exists
+- GIF/demo exists
+- install/status/uninstall are reliable
+- issue templates and Discussions are ready
+- release checklist passes
+
+### Launch CTA
+
+Ask for feedback, not stars.
+
+Suggested CTA:
+
+```text
+If you try it in a real Django project, I would love to hear where completion feels wrong or what command should become smarter next.
+```
+
+### First 4 Weeks After v2 Launch
+
+Public maintenance promise:
+
+- First 48 hours: respond quickly to install/shell breakage.
+- First 2 weeks: prioritize bug fixes and docs clarifications.
+- First 4 weeks: collect feature requests and decide v2.1/v3 scope.
+- After that: normal open-source maintenance cadence.
+
+Post-launch decision rules:
+
+- If most feedback is install/shell confusion: v2.1 focuses on reliability, docs, and status diagnostics.
+- If most feedback is "complete X command too": v2.1 adds command-specific rules such as `sqlmigrate`, `showmigrations`, or `makemigrations`.
+- If most feedback is wrapper/shell compatibility: v2.1 improves invocation compatibility.
+- If feedback is quiet but usage grows: v2.1 focuses on polish and fish preparation.
+
+Badges:
+
+- Use practical trust badges:
+  - PyPI version
+  - Python versions
+  - Django versions
+  - CI status
+  - license
+- Avoid early download-count badges.
+- Avoid badges that are likely to go stale.
+
+---
+
+## Implementation Steps
+
+### v1 Completion and Quiet Release
+
+- [x] Project scaffolding
+- [x] Cache builder
+- [x] App classifier
+- [x] Auto-refresh hook
+- [x] Fuzzy helper / command suggestion coverage
+- [x] `autocomplete` management command
+- [x] bash/zsh templates
+- [x] Integration tests
+- [x] Package metadata
+- [ ] Add `DJANGO_COMPLETION_AUTO_REFRESH`
+- [ ] Ensure `autocomplete install` creates/refreshes cache immediately
+- [ ] Ensure `autocomplete uninstall` removes managed script files and empty managed directory
+- [ ] README: replace placeholder content
+- [ ] Docs: installation, usage, how it works, troubleshooting basics
+- [ ] Changelog: accurate `0.1.0`
+- [ ] Verify repository/docs links
+- [ ] Verify `.django-completion-cache.json` ignored and absent from git
+- [ ] Run final release checks
+- [ ] Publish quiet `0.1.0` to PyPI
+
+### v2 Core Implementation
+
+- [ ] Add `schema_version: 2`
+- [ ] Add migration discovery to cache
+- [ ] Respect `MIGRATION_MODULES`
+- [ ] Add cache warning collection
+- [ ] Add internal Python completion helper
+- [ ] Refactor bash template to call helper
+- [ ] Refactor zsh template to call helper
+- [ ] Implement `migrate` app-label filtering
+- [ ] Implement `migrate <app> <migration>` completion
+- [ ] Include `zero` for migration target completion
+- [ ] Preserve v1 fallback behavior for non-`migrate` commands
+- [ ] Support path-like `manage.py`
+- [ ] Support `uv run python manage.py` if straightforward
+- [ ] Add script version metadata
+- [ ] Make `status` report script current/outdated
+- [ ] Add `status --verbose`
+- [ ] Add outdated schema reporting
+- [ ] Add v2 helper unit tests
+- [ ] Thin shell subprocess tests
+- [ ] Manual bash/zsh install/uninstall tests
+
+### v2 Launch Assets
+
+- [ ] Launch README
+- [ ] Full docs
+- [ ] Compatibility matrix
+- [ ] Troubleshooting page
+- [ ] How-it-works page
+- [ ] Safety/privacy section
+- [ ] Changelog `0.2.0`
+- [ ] GitHub issue templates
+- [ ] GitHub Discussions
+- [ ] Demo project
+- [ ] v2 GIF
+- [ ] Reddit/LinkedIn launch copy
+
+### v2 Release Checklist
+
+- [ ] `uv run pytest -q`
+- [ ] `uv run ruff check .`
+- [ ] `uv run ty check`
+- [ ] `uv build`
+- [ ] wheel contains `py.typed`
+- [ ] wheel contains shell templates
+- [ ] README updated
+- [ ] docs updated
+- [ ] changelog updated
+- [ ] issue templates added
+- [ ] demo GIF recorded
+- [ ] `autocomplete status --verbose` checked
+- [ ] install/uninstall manually tested in bash
+- [ ] install/uninstall manually tested in zsh
+- [ ] quiet v1 lessons reviewed
+
+---
+
+## Roadmap
+
+### v2 Core
+
+- Migration-aware completion for `migrate`.
+- Context-aware filtering for apps with migrations.
+- Internal Python completion helper.
+- Cache schema versioning.
+- Script version detection.
+- Better `status` diagnostics and `--verbose`.
+- Launch-ready README/docs/troubleshooting/demo.
+
+### v2 Stretch
+
+- Local-app filtering for `makemigrations`.
+- Better origin categories, e.g. `django` vs `pip`, if easy.
+- `uv run python manage.py` support if not already covered by generic parser.
+
+### v2.1 Candidates
+
+Chosen based on post-launch feedback:
+
+- reliability/docs/status improvements
+- `sqlmigrate`
+- `showmigrations`
+- `makemigrations`
+- wrapper compatibility
+- shell edge cases
+
+### v3
+
+- Fish shell support.
+- Broader wrappers:
+  - `poetry run python manage.py`
+  - `pipenv run python manage.py`
+- Docker integration tests.
+
+### Later
+
+- Private GitHub/package-source classification.
+- User-configurable command rules.
+- Model-name completion.
+- Settings-module completion.
+- Database-aware applied/unapplied migration completion, only if there is strong demand.
+- Django Enhancement Proposal exploration after adoption evidence.
+
+---
+
+## Known Issues / Open Questions
+
+- No current v1 runtime issues tracked here.
+- v2 decisions above are accepted design direction; implementation may still surface shell-specific details.

--- a/V2_ISSUES.md
+++ b/V2_ISSUES.md
@@ -1,0 +1,1434 @@
+# V2 Implementation Issues
+
+Five sequentially-ordered, independently-grabbable issues. Each is a vertical slice: defines its own files, acceptance criteria, and exit test. Dependencies are explicit.
+
+Issues 1 → 2 → 3 form the core chain. Issue 4 (status improvements) depends on 3. Issue 5 (docs) can proceed in parallel with any of the others and is finalized last.
+
+---
+
+## Issue 1 — Cache v2: schema versioning + migration discovery
+
+**Goal:** `build_cache()` produces a v2 cache — includes `schema_version`, a `migrations` dict keyed by app label, and a `warnings` list for apps whose migrations could not be inspected. Shell templates and status command are not touched in this issue.
+
+**Files:**
+- `src/django_completion/cache.py` — extend `build_cache()`
+- `tests/test_cache.py` — new tests for migration discovery
+
+**What to implement:**
+
+In `build_cache()`:
+
+1. Add `"schema_version": 2` to the returned dict.
+2. After building `app_labels`, iterate over app configs and discover migration files on disk:
+   - For each app, determine the migrations module path:
+     - Check `settings.MIGRATION_MODULES` if it exists.
+     - If the key is present and the value is `None` → app has no migrations, skip it.
+     - If the key is present and the value is a string → use that as the module dotted path.
+     - If the key is absent → use `{app_label}.migrations` (the default).
+   - Resolve the module path to a filesystem directory using `importlib.util.find_spec` or `importlib.import_module`.
+   - If the module cannot be imported or found → skip the app, append a warning string to `warnings`.
+   - List `.py` files in the directory, excluding `__init__.py`, `__pycache__`, non-Python files, and hidden/private files (names starting with `_` other than `__init__`).
+   - Strip the `.py` suffix.
+   - Sort names alphabetically.
+   - Store under `migrations[app_label]`.
+3. Add `"migrations": {...}` and `"warnings": [...]` to the returned dict.
+
+Cache compatibility rule: `read_cache()` needs no changes — callers that check `schema_version` are responsible for handling missing keys.
+
+**Acceptance criteria:**
+- `build_cache()["schema_version"]` == 2.
+- `build_cache()["migrations"]` is a dict; keys are app labels that have migrations.
+- Django's built-in apps (`auth`, `contenttypes`, `sessions`) appear as keys since they ship migrations.
+- `build_cache()["migrations"]["auth"]` contains `"0001_initial"` (no `.py` suffix).
+- `build_cache()["warnings"]` is a list (may be empty on a clean testproject).
+- `settings.MIGRATION_MODULES = {"auth": None}` → `"auth"` absent from `migrations` dict.
+- `settings.MIGRATION_MODULES = {"auth": "nonexistent.module"}` → `"auth"` absent from `migrations`, a warning string is appended.
+- `uv run pytest tests/test_cache.py -q` passes.
+- `uv run ruff check src/django_completion/cache.py` passes.
+- `uv run ty check` passes.
+
+**Notes:**
+- Do not check database state. Discovery is purely from the filesystem.
+- The `warnings` list is informational; a non-empty list must not prevent `build_cache()` from returning normally.
+- The testproject has no local apps — test `MIGRATION_MODULES` cases using the `settings` fixture and Django's own apps.
+
+---
+
+## Issue 2 — Internal Python completion helper (`_complete`)
+
+**Goal:** A new internal module `django_completion._complete` callable as `python -m django_completion._complete` that reads a v2 cache file and outputs shell completions. All completion decision logic lives here, not in the shell templates. Shell templates are not touched in this issue.
+
+**Dependency:** Issue 1 (cache must contain `migrations` and `schema_version`).
+
+**Files:**
+- `src/django_completion/_complete.py` — new module
+- `tests/test_complete.py` — new test file
+
+**CLI contract:**
+
+```
+python -m django_completion._complete \
+  --cache /path/to/.django-completion-cache.json \
+  --words-json '["python", "manage.py", "migrate", "accounts", ""]' \
+  --cword 4 \
+  --format bash
+```
+
+Arguments:
+- `--cache` — absolute path to the cache JSON file. If missing or unreadable, print nothing and exit 0.
+- `--words-json` — JSON array of the current command line tokens (all words including the one being completed).
+- `--cword` — integer index into `words-json` of the word being completed (0-based).
+- `--format` — `bash` (plain newline-delimited) or `zsh` (`candidate:description` newline-delimited). Default: `bash`.
+
+**Completion logic:**
+
+1. Load cache from `--cache`. If any error → exit 0 silently.
+2. Find the manage.py token: scan `words[0 .. cword-1]` for the last word ending in `manage.py`. If not found → exit 0.
+3. Let `pos = cword - manage_idx` (position relative to manage.py).
+4. Let `cur = words[cword]` (the word being completed, may be empty string).
+5. Let `cmd = words[manage_idx + 1]` if `pos >= 2`, else `None`.
+
+Completion rules by position:
+
+| pos | cur starts with `-` | cmd       | Complete                                                     |
+|-----|---------------------|-----------|--------------------------------------------------------------|
+| 1   | —                   | —         | All command names                                            |
+| 2   | yes                 | any       | Options for `cmd`                                            |
+| 2   | no                  | `migrate` | App labels that appear in `cache["migrations"]`, local-first |
+| 2   | no                  | other     | All app labels + options for `cmd`                           |
+| 3   | yes                 | `migrate` | Options for `migrate`                                        |
+| 3   | no                  | `migrate` | Migration names for `words[manage_idx+2]` + `"zero"`         |
+| ≥3  | yes                 | other     | Options for `cmd`                                            |
+| ≥3  | no                  | other     | All app labels + options for `cmd`                           |
+
+Output format:
+- `bash`: one candidate per line, plain string.
+- `zsh`: one `candidate:description` per line. Colons inside descriptions must be escaped as `\:`. For commands, description = `command_help[cmd]`. For options, description = `command_option_descriptions[cmd][opt]`. For app labels, description = `[{origin}]`. For migration names, description is empty.
+
+**Acceptance criteria (unit tests — no shell subprocess needed):**
+
+Each test below calls a helper function `complete(cache, words, cword, fmt="bash") -> list[str]` that wraps the module's core logic (not the CLI) for ease of testing.
+
+- `["manage.py", ""]`, cword=1 → command names list.
+- `["python", "manage.py", ""]`, cword=2 → command names list.
+- `["./manage.py", ""]`, cword=1 → command names list (path-like first token).
+- `["uv", "run", "python", "manage.py", ""]`, cword=4 → command names list.
+- `["manage.py", "migrate", ""]`, cword=2 → only apps present in `migrations` key (not all app labels).
+- `["manage.py", "migrate", "accounts", ""]`, cword=3 → migration names for `accounts` + `"zero"`.
+- `["manage.py", "migrate", "--"]`, cword=2 → options only, no app labels.
+- `["manage.py", "migrate", "accounts", "--"]`, cword=3 → options only.
+- `["manage.py", "shell", ""]`, cword=2 → all app labels + options (v1 fallback).
+- `["manage.py", "shell", "--"]`, cword=2 → options only.
+- Cache file missing → empty list.
+- v1 cache (no `schema_version`, no `migrations`) → commands/options/app-labels still work; migrate pos-2 falls back to all app labels.
+- `["python", ""]`, cword=1 → empty (no manage.py token found).
+- `zsh` format: command candidates are `name:description`, colons in descriptions escaped.
+- `zsh` format: app label candidates are `name:[local]` or `name:[pip]`.
+
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+**Notes:**
+- Keep the module small. The full logic should fit in ~100 lines.
+- `_complete.py` is internal. Do not add public docstrings or expose it in `__init__.py`.
+- Use `if __name__ == "__main__"` or `__main__` at module level to handle CLI entry.
+- `importlib` is not needed here — the module only reads JSON; it never imports Django.
+
+---
+
+## Issue 3 — Shell templates: thin wrappers calling the Python helper
+
+**Goal:** Replace inline `python3 -c '...'` snippets in both shell templates with calls to `python3 -m django_completion._complete`. End-to-end: `python manage.py migrate accounts <TAB>` returns migration names in a live shell. Shell tests updated to use a v2 fixture.
+
+**Dependency:** Issue 2 (the `_complete` module must exist).
+
+**Files:**
+- `src/django_completion/scripts/bash_completion.sh.tmpl` — refactor
+- `src/django_completion/scripts/zsh_completion.zsh.tmpl` — refactor
+- `tests/test_shell.py` — update `cache_dir` fixture to v2 shape; thin down or replace Python-inline tests; add a test verifying the helper is called
+
+**What to change in the bash template:**
+
+Replace each `python3 -c '...'` block with a call to the helper. The helper is called with words built from `${COMP_WORDS[@]}` and `$COMP_CWORD`. Example pattern:
+
+```bash
+local words_json
+words_json=$(printf '%s\n' "${COMP_WORDS[@]}" | python3 -c "
+import json, sys
+print(json.dumps(sys.stdin.read().splitlines()))
+")
+local candidates
+candidates=$(python3 -m django_completion._complete \
+  --cache "$cache_file" \
+  --words-json "$words_json" \
+  --cword "$COMP_CWORD" \
+  --format bash 2>/dev/null)
+COMPREPLY=($(compgen -W "$candidates" -- "$cur"))
+```
+
+The two existing functions (`_django_manage_completion` for `manage.py` and `_django_python_completion` for `python`/`python3`) can be unified into a single function backed by the helper, since the helper itself handles manage.py token detection. Unify only if it simplifies the template; do not unify for its own sake.
+
+`complete` registrations to keep/add:
+- `complete -F _django_manage_completion manage.py` (existing)
+- `complete -o default -F _django_python_completion python python3` (existing)
+- `complete -o default -F _django_python_completion uv` — add this to enable `uv run python manage.py` support. The `-o default` fallback means uv's own filename completion fires when COMPREPLY is empty (i.e., when no manage.py token is in the words). This is an acceptable tradeoff; uv's own shell integration is usually installed separately and takes precedence when both are active.
+
+**What to change in the zsh template:**
+
+Same logic: replace inline Python snippets with calls to the helper using `--format zsh`. The helper's `candidate:description` lines are already compatible with `_describe`.
+
+For zsh, add `compdef _django_python_manage uv` alongside existing `compdef` lines. The function already handles the case where manage.py is absent (calls `_default`).
+
+**Updated `cache_dir` fixture in `tests/test_shell.py`:**
+
+Add `schema_version`, `migrations`, and `warnings` to the fixture dict:
+```python
+"schema_version": 2,
+"migrations": {
+    "myapp": ["0001_initial", "0002_add_user"],
+    "auth": ["0001_initial"],
+},
+"warnings": [],
+```
+
+**New shell tests to add:**
+- `test_bash_migrate_completes_migration_apps` — `manage.py migrate <TAB>` returns only apps that appear in `migrations` key (`myapp`, `auth`), not apps absent from it.
+- `test_bash_migrate_completes_migration_names` — `manage.py migrate myapp <TAB>` returns `0001_initial`, `0002_add_user`, `zero`.
+- `test_bash_helper_is_invoked` — source the template and verify it contains `django_completion._complete` (string check on the template file, not subprocess).
+
+Existing shell tests (commands, options, app labels, no-cache) should continue to pass with the updated fixture.
+
+**Acceptance criteria:**
+- `uv run pytest tests/test_shell.py -q` passes.
+- `uv run pytest -q` (full suite) passes.
+- Manually: `source` the bash template in a shell that has `django_completion` installed, then `python manage.py migrate <TAB>` completes migration app labels.
+- Manually: `python manage.py migrate auth <TAB>` completes migration names + `zero`.
+- `uv run ruff check src/django_completion/scripts/` passes (skip if ruff doesn't lint `.tmpl`; verify the Python-side changes instead).
+- `uv run ty check` passes.
+
+**Notes:**
+- Path-like `./manage.py <TAB>` as the first and only token requires a `complete` wildcard or bash hook (`complete -D`) that is out of scope for this issue. The helper already handles `./manage.py` when it appears mid-command (e.g., `python ./manage.py <TAB>`). Document this limitation in a comment in the template.
+- Keep the shell templates readable. Inline Python for JSON building is acceptable if it remains short (< 5 lines). The goal is to remove completion decision logic from the templates, not all Python.
+
+---
+
+## Issue 4 — `autocomplete status`: verbose output + script version tracking
+
+**Goal:** `status` shows v2-relevant counts and detects stale installed scripts. `status --verbose` outputs full diagnostic info. `autocomplete install` embeds the package version in the generated script file.
+
+**Dependency:** Issue 3 (need to know what a v2 script looks like before defining "current vs outdated").
+
+**Files:**
+- `src/django_completion/management/commands/autocomplete.py` — `_install`, `_status`
+- `tests/test_shell.py` or new `tests/test_autocomplete.py` — status tests
+
+**Changes to `_install`:**
+
+Before writing the script content, prepend a version comment:
+```
+# django-completion version: {version}
+```
+Where `{version}` comes from `importlib.metadata.version("django-completion")` or is read from `pyproject.toml`. Using `importlib.metadata` is preferred.
+
+The script file on disk then starts with this line. `_status` compares it against the current package version to determine currency.
+
+**Changes to `_status`:**
+
+Add `--verbose` argument to the `status` subparser.
+
+Default (non-verbose) output — replace current output with v2-aware version:
+```
+Cache: /path/to/.django-completion-cache.json (age 42s, fresh)
+Schema: v2 (current)          ← or "v1 (outdated)" if schema_version missing/< 2
+Commands: 28
+Apps: 12
+Apps with migrations: 8
+Warnings: 0
+bash hook: installed
+zsh hook: installed
+bash script: current           ← or "outdated (script v0.1.0, package v0.2.0)"
+zsh script: not installed
+```
+
+Verbose output (`--verbose`):
+```
+Cache path: /path/to/.django-completion-cache.json
+Generated: 2026-04-28 14:00:00 UTC
+Schema version: 2
+Commands: 28
+Apps: 12
+Apps with migrations: 8 (accounts, auth, billing, blog, ...)
+Warnings: 0
+bash hook: /home/user/.bashrc (installed)
+zsh hook: /home/user/.zshrc (not installed)
+bash script: /home/user/.local/share/django-completion/completion.bash (v0.2.0, current)
+zsh script: not installed
+Package version: 0.2.0
+```
+
+Script currency check: read the first line of the installed script file, parse the version comment, compare to the current package version. If the file does not exist or has no version comment → report "outdated".
+
+**Acceptance criteria:**
+- `autocomplete status` output includes schema version, apps-with-migrations count, and script currency.
+- `autocomplete status --verbose` includes all fields listed above.
+- After `autocomplete install`, the script file at `~/.local/share/django-completion/completion.bash` starts with `# django-completion version: 0.1.0` (current version).
+- `autocomplete status` reports `bash script: current` after a fresh install.
+- Manually editing the version comment in the installed file to `0.0.1` causes `autocomplete status` to report `outdated`.
+- Cache with `schema_version` missing → `status` reports `v1 (outdated)`.
+- `uv run pytest tests/ -q` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 5 — Launch assets: README, docs, changelog
+
+**Goal:** All text assets are launch-ready for `0.2.0`. No TODO placeholders. README leads with the migrate demo. Docs cover installation, usage, how it works, troubleshooting, compatibility, safety/privacy, and API reference.
+
+**Dependency:** Issues 1–4 must be complete so the docs accurately describe implemented behavior.
+
+**Files:**
+- `README.md` — rewrite for v2 public launch
+- `CHANGELOG/0.2.0.md` — new file
+- `docs/installation.md` — update for v2
+- `docs/usage.md` — update for v2 (migrate completion, uv invocation)
+- `docs/how_it_works.md` — update (Python helper, monkey-patch wording from PLAN)
+- `docs/troubleshooting.md` — expand with v2 scenarios
+- `docs/api.md` — update (v2 cache schema, `status --verbose`)
+- `.github/ISSUE_TEMPLATE/` — add bug-report, completion-wrong, feature-request, shell-environment templates
+- `pyproject.toml` — bump `version` to `0.2.0` and update `Development Status` classifier to `4 - Beta`
+
+**README structure (from PLAN):**
+
+1. Headline + subheadline.
+2. Terminal demo block showing `migrate <TAB>`, `migrate accounts <TAB>`, `runserver --<TAB>`.
+3. Installation (`pip install` / `uv add`).
+4. Setup (INSTALLED_APPS → `autocomplete install` → restart shell).
+5. Status / refresh / uninstall.
+6. Compatibility matrix (Python 3.10+, Django 4.2+, bash/zsh, Linux/macOS).
+7. Safety and privacy (no telemetry, no network, no DB, shell edits are reversible — exact wording from PLAN).
+8. Limitations (no fish, no django-admin, no Windows official support, no global options before command).
+9. Short roadmap (v2.1 candidates, v3 fish/wrappers).
+10. Long-term core wording (exact phrase from PLAN).
+
+**Changelog `0.2.0.md`** must accurately describe:
+- Migration-aware completion for `migrate` (app labels + migration names + `zero`).
+- Internal Python completion helper replacing inline shell snippets.
+- `uv run python manage.py` support.
+- Cache schema v2 with `schema_version`, `migrations`, `warnings`.
+- `autocomplete status --verbose`.
+- Script version tracking and currency detection.
+
+**Issue templates** must request:
+- OS, shell, Python version, Django version, install method.
+- Invocation style.
+- Output of `python manage.py autocomplete status --verbose`.
+
+**Acceptance criteria:**
+- `README.md` has no TODO or placeholder text.
+- All five docs pages are complete per PLAN section "Documentation Pages".
+- Troubleshooting covers all nine scenarios listed in PLAN.
+- `CHANGELOG/0.2.0.md` exists and accurately reflects implemented behavior.
+- `pyproject.toml` version is `0.2.0`.
+- At least two GitHub issue templates exist under `.github/ISSUE_TEMPLATE/`.
+- `uv build` produces a `0.2.0` wheel.
+- `uv run pytest -q`, `uv run ruff check .`, `uv run ty check` all pass.
+
+---
+
+# 0.2.1 Patch Issues
+
+Five fixes discovered during real-world testing after `0.2.0` shipped. Issues 1–4 are code changes; Issue 5 is docs-only. All are independent and can be grabbed in any order.
+
+---
+
+## Issue 0.2.1-1 — `autocomplete <TAB>` completes subcommands, not app labels
+
+**Goal:** `python manage.py autocomplete <TAB>` completes `install`, `status`, `refresh`, `uninstall` — not app labels.
+
+**Root cause:** `_complete.py` has no special case for `autocomplete`. It falls through to the v1 fallback (app labels + options), which is wrong because `autocomplete` takes subcommands, not app labels.
+
+**Files:**
+- `src/django_completion/_complete.py` — add `autocomplete` as a special case
+- `tests/test_complete.py` — new tests
+
+**What to implement:**
+
+In the completion logic, add a rule for `cmd == "autocomplete"` at pos 2:
+- Complete the hardcoded list: `["install", "status", "refresh", "uninstall"]`.
+- If `cur` starts with `-`, fall through to options as usual.
+
+The subcommand list is static and does not need to be read from cache.
+
+**Acceptance criteria:**
+- `["manage.py", "autocomplete", ""]`, cword=2 → `["install", "refresh", "status", "uninstall"]` (or any order).
+- `["manage.py", "autocomplete", "s"]`, cword=2 → completions starting with `s` (shell filters, but list must include `status`).
+- `["manage.py", "autocomplete", "--"]`, cword=2 → options only (existing behavior).
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.1-2 — `migrate <TAB>` shows local apps before pip/Django apps
+
+**Goal:** `python manage.py migrate <TAB>` returns apps with migrations sorted local-first, then pip/django apps — not purely alphabetically.
+
+**Root cause:** `_migration_app_labels()` in `_complete.py` returns apps in the order they appear in `cache["migrations"]`, which is alphabetical from `build_cache()`. The `origin` field in `cache["app_labels"]` carries `"local"` vs `"pip"` but is not consulted during migration app ordering.
+
+**Files:**
+- `src/django_completion/_complete.py` — update `_migration_app_labels()` to sort by origin
+- `tests/test_complete.py` — new ordering test
+
+**What to implement:**
+
+In `_migration_app_labels(cache)`:
+1. Build a lookup `{label: origin}` from `cache["app_labels"]`.
+2. Sort migration app labels: `origin == "local"` first, then everything else, alphabetically within each group.
+
+**Acceptance criteria:**
+- Given cache with local app `accounts` and pip app `auth`, both in `migrations` dict: `migrate <TAB>` returns `accounts` before `auth`.
+- Alphabetical order is preserved within each group.
+- Apps absent from `cache["app_labels"]` (unknown origin) sort after local apps, treated as non-local.
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.1-3 — Status cache age is human-readable
+
+**Goal:** `autocomplete status` shows `age 2 days` or `age 47 minutes` instead of `age 203692s`.
+
+**Root cause:** `_status()` in `autocomplete.py` formats age as raw seconds. There is no human-readable duration formatter.
+
+**Files:**
+- `src/django_completion/management/commands/autocomplete.py` — add duration formatter, apply to status output
+- `tests/test_shell.py` or new `tests/test_autocomplete.py` — test the formatter
+
+**What to implement:**
+
+Add a small helper (≤10 lines):
+
+```python
+def _human_age(seconds: float) -> str:
+    ...
+```
+
+Conversion table:
+- `< 60` → `"{n}s"`
+- `< 3600` → `"{n} minutes"` (or `"1 minute"`)
+- `< 86400` → `"{n} hours"` (or `"1 hour"`)
+- `>= 86400` → `"{n} days"` (or `"1 day"`)
+
+Apply to the `(age ..., fresh/stale)` part of the default status output and the verbose `Generated:` line.
+
+**Acceptance criteria:**
+- `_human_age(30)` → `"30s"`.
+- `_human_age(90)` → `"1 minute"` or `"2 minutes"`.
+- `_human_age(3700)` → `"1 hour"` or similar.
+- `_human_age(203692)` → `"2 days"` or similar.
+- `autocomplete status` output contains `age 2 days` not `age 203692s` for a 2-day-old cache.
+- `uv run pytest tests/ -q` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.1-4 — Post-uninstall message: remind user to reload shell
+
+**Goal:** After `autocomplete uninstall`, the output tells the user to run `source ~/.bashrc` (or `~/.zshrc`) or open a new terminal. Without this, completion functions remain loaded in the current session and the user thinks uninstall failed.
+
+**Root cause:** `_uninstall()` in `autocomplete.py` prints a success message but does not mention that the current shell session still has the functions loaded in memory.
+
+**Files:**
+- `src/django_completion/management/commands/autocomplete.py` — update `_uninstall()` output
+
+**What to implement:**
+
+After the existing uninstall success message, print:
+
+```
+To complete removal from your current session, run:
+  source ~/.bashrc   # or ~/.zshrc
+Or open a new terminal.
+
+Note: .django-completion-cache.json was left in place. Delete it manually if needed.
+```
+
+The shell rc file path should reflect the shell that was uninstalled (detect from the installed hook or fall back to both).
+
+**Acceptance criteria:**
+- Running `autocomplete uninstall` prints a message that mentions `source` and/or opening a new terminal.
+- The cache note is included in the output.
+- `uv run pytest tests/ -q` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.1-5 — Troubleshooting: "Unknown command: 'autocomplete'" (docs only)
+
+**Goal:** A user who sees `Unknown command: 'autocomplete'` can find the answer in troubleshooting docs without opening a GitHub issue.
+
+**Root cause:** When `DJANGO_SETTINGS_MODULE` (or equivalent env vars) is not set in the terminal, Django cannot load settings, cannot discover installed apps, and therefore does not see `django_completion` in `INSTALLED_APPS`. The `autocomplete` management command does not exist from Django's perspective. There is no code-side intercept — this fires at Django's command-discovery layer before any `django_completion` code runs. Shell completion still works because it reads the cache file and never imports Django.
+
+**Files:**
+- `docs/troubleshooting.md` — add new entry
+
+**What to implement:**
+
+Add a troubleshooting entry:
+
+**"'Unknown command: autocomplete' error"**
+
+Explain:
+- The `autocomplete` management command requires Django to be fully configured (settings loaded, app discovered).
+- Tab completion works independently because it reads the cache file and does not import Django.
+- The fix is to ensure environment variables (`DJANGO_SETTINGS_MODULE`, database credentials, etc.) are set before running `python manage.py autocomplete ...`.
+- Show the env-loading pattern from the project's `.env` setup.
+- Note that `python manage.py autocomplete refresh` and `status` require the same env setup.
+
+**Acceptance criteria:**
+- `docs/troubleshooting.md` contains an entry for this error.
+- The entry explains the root cause (settings not loaded) and the fix (load env vars).
+- No code changes required.
+- `uv run ruff check .` and `uv run ty check` still pass.
+
+---
+
+# 0.2.2 Issues
+
+Four improvements that require per-command knowledge. All changes are in `_complete.py` and `tests/test_complete.py`. Issues are independent but share context — read Issue 0.2.2-1 first as it defines the whitelist used by the others.
+
+Dependencies: 0.2.2-2, 0.2.2-3, 0.2.2-4 depend on the whitelist introduced in 0.2.2-1.
+
+---
+
+## Issue 0.2.2-1 — Replace generic fallback with command whitelist
+
+**Goal:** For commands not known to accept app labels (`runserver`, `shell`, `createsuperuser`, etc.), complete options only — not app labels. App label completion is only offered for commands where it is semantically useful.
+
+**Root cause:** The v1 generic fallback shows "app labels + options" for every command that is not `migrate`. This pollutes completion for `runserver`, `shell`, and dozens of other commands that never take app labels.
+
+**Files:**
+- `src/django_completion/_complete.py` — replace generic fallback with whitelist check
+- `tests/test_complete.py` — new tests for whitelist behavior
+
+**What to implement:**
+
+Define a frozenset of Django built-in commands that accept app labels as positional arguments:
+
+```python
+_APP_LABEL_COMMANDS = frozenset({
+    "migrate",
+    "makemigrations",
+    "showmigrations",
+    "sqlmigrate",
+    "dumpdata",
+    "test",
+    "check",
+})
+```
+
+In the completion logic, replace the generic fallback rule:
+- If `cmd` is in `_APP_LABEL_COMMANDS` → app labels + options (existing fallback behavior).
+- If `cmd` is not in `_APP_LABEL_COMMANDS` → options only.
+
+`migrate`, `makemigrations`, `showmigrations`, and `sqlmigrate` each get their own special cases (Issues 0.2.2-2 through 0.2.2-4); the whitelist controls the generic fallback for `dumpdata`, `test`, `check`, and any future commands added to the set.
+
+**Acceptance criteria:**
+- `["manage.py", "runserver", ""]`, cword=2 → options only, no app labels.
+- `["manage.py", "shell", ""]`, cword=2 → options only, no app labels.
+- `["manage.py", "dumpdata", ""]`, cword=2 → app labels + options (whitelist hit).
+- `["manage.py", "test", ""]`, cword=2 → app labels + options (whitelist hit).
+- `["manage.py", "mycustomcommand", ""]`, cword=2 → options only (unknown command, safe default).
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+**Notes:**
+- Custom management commands not in the whitelist fall back to options-only. This is the safe default — the user can still type an app label manually.
+- Do not try to detect what custom commands accept at completion time; that would require importing Django.
+
+---
+
+## Issue 0.2.2-2 — `makemigrations <TAB>` completes local apps only
+
+**Goal:** `python manage.py makemigrations <TAB>` completes only apps where `origin == "local"` — not pip packages or Django contrib apps. Running `makemigrations` on `auth` or `contenttypes` is never intentional.
+
+**Dependency:** Issue 0.2.2-1 (whitelist).
+
+**Files:**
+- `src/django_completion/_complete.py` — add `makemigrations` special case
+- `tests/test_complete.py` — new tests
+
+**What to implement:**
+
+Add a helper `_local_app_labels(cache) -> list[str]` that returns labels where `origin == "local"`, preserving alphabetical order.
+
+Add a completion rule for `cmd == "makemigrations"` at pos ≥ 2:
+- If `cur` starts with `-` → options only.
+- Otherwise → local app labels only (from `_local_app_labels`).
+
+**Acceptance criteria:**
+- `["manage.py", "makemigrations", ""]`, cword=2 → only local apps, no `auth`, `contenttypes`, `sessions`.
+- `["manage.py", "makemigrations", "--"]`, cword=2 → options only.
+- Given cache with local app `accounts` and pip app `authtoken`: `makemigrations <TAB>` returns `accounts` but not `authtoken`.
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.2-3 — `showmigrations <TAB>` completes apps from migrations dict
+
+**Goal:** `python manage.py showmigrations <TAB>` completes only apps that have migrations, local-first — same filtering as `migrate` at pos 2.
+
+**Dependency:** Issue 0.2.2-1 (whitelist). Reuses `_migration_app_labels()` from Issue 0.2.1-2.
+
+**Files:**
+- `src/django_completion/_complete.py` — add `showmigrations` special case
+- `tests/test_complete.py` — new tests
+
+**What to implement:**
+
+Add a completion rule for `cmd == "showmigrations"` at pos 2:
+- If `cur` starts with `-` → options only.
+- Otherwise → `_migration_app_labels(cache)` (local-first, same as `migrate`).
+
+`showmigrations` does not take a migration name at pos 3 (unlike `migrate` and `sqlmigrate`), so pos ≥ 3 falls through to options only.
+
+**Acceptance criteria:**
+- `["manage.py", "showmigrations", ""]`, cword=2 → apps from `migrations` dict, local-first.
+- `["manage.py", "showmigrations", "--"]`, cword=2 → options only.
+- `["manage.py", "showmigrations", "accounts", ""]`, cword=3 → options only.
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.2-4 — `sqlmigrate <app> <migration> <TAB>` smart completion
+
+**Goal:** `python manage.py sqlmigrate <TAB>` completes app labels from migrations dict; `python manage.py sqlmigrate accounts <TAB>` completes migration names for that app. Same two-level logic as `migrate`.
+
+**Dependency:** Issue 0.2.2-1 (whitelist). Reuses `_migration_app_labels()` and `_migration_names()` from Issue 0.2.1-2.
+
+**Files:**
+- `src/django_completion/_complete.py` — add `sqlmigrate` special case
+- `tests/test_complete.py` — new tests
+
+**What to implement:**
+
+Add completion rules for `cmd == "sqlmigrate"`:
+- pos 2, `cur` starts with `-` → options only.
+- pos 2, no dash → `_migration_app_labels(cache)` (local-first).
+- pos 3, `cur` starts with `-` → options only.
+- pos 3, no dash → `_migration_names(cache, words[manage_idx + 2])` (no `"zero"` — `sqlmigrate` requires an exact applied migration, `zero` is not valid).
+- pos ≥ 4 → options only.
+
+Note: unlike `migrate`, do **not** append `"zero"` to the migration names list. `sqlmigrate` requires an exact migration name; `zero` is a `migrate`-specific target.
+
+**Acceptance criteria:**
+- `["manage.py", "sqlmigrate", ""]`, cword=2 → apps from `migrations` dict.
+- `["manage.py", "sqlmigrate", "accounts", ""]`, cword=3 → migration names for `accounts`, no `"zero"`.
+- `["manage.py", "sqlmigrate", "--"]`, cword=2 → options only.
+- `["manage.py", "sqlmigrate", "accounts", "--"]`, cword=3 → options only.
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+# 0.2.3 Issues
+
+Four independent improvements surfaced by architecture review. All are self-contained; no ordering dependency between them.
+
+---
+
+## Issue 0.2.3-1 — Delete `fuzzy.py`: unwired module with no production callers
+
+**Goal:** Remove `src/django_completion/fuzzy.py` and `tests/test_fuzzy.py`. The module was scaffolded early for a "did you mean?" feature that was never wired into a call site. Tab completion has no output path for suggestions — the shell presents candidates or nothing. Django itself already shows "Unknown command: 'migarte'. Did you mean migrate?" at its own command-discovery layer before any `django_completion` code runs, so the feature is doubly covered. Keeping the module creates a false impression that command suggestion is implemented by this package.
+
+**Files:**
+- `src/django_completion/fuzzy.py` — delete
+- `tests/test_fuzzy.py` — delete
+
+**What to implement:**
+
+Delete both files. Before deleting, run:
+```bash
+grep -r "from django_completion.fuzzy\|import fuzzy" src/
+```
+to confirm no production caller exists (expected: no output).
+
+**Acceptance criteria:**
+- `src/django_completion/fuzzy.py` does not exist.
+- `tests/test_fuzzy.py` does not exist.
+- `grep -r "from django_completion.fuzzy" src/` returns nothing.
+- `uv run pytest -q` passes.
+- `uv run ruff check .` passes.
+- `uv run ty check` passes.
+
+**Notes:**
+- If a "did you mean?" feature is added in a future release, re-introduce `fuzzy.py` at that point with a concrete call site (e.g., `_complete.py` or the `autocomplete` management command) and tests that exercise it through the caller, not in isolation.
+
+---
+
+## Issue 0.2.3-2 — Surface command introspection failures as warnings in `build_cache()`
+
+**Goal:** When `load_command_class` or `create_parser` raises during cache build, append a warning to the `warnings` list instead of silently discarding the error. Migration discovery already applies this contract — command introspection should match it. A user who gets empty option completions for a broken command can then see why via `autocomplete status --verbose`.
+
+**Files:**
+- `src/django_completion/cache.py` — update the command introspection loop in `build_cache()`
+- `tests/test_cache.py` — add a test for warning on uninspectable command class
+
+**What to implement:**
+
+In `build_cache()`, change the bare `except Exception` block:
+
+```python
+# before
+except Exception:
+    command_help[cmd_name] = ""
+    command_options[cmd_name] = []
+    command_option_descriptions[cmd_name] = {}
+```
+
+to:
+
+```python
+# after
+except Exception as exc:
+    command_help[cmd_name] = ""
+    command_options[cmd_name] = []
+    command_option_descriptions[cmd_name] = {}
+    warnings.append(f"Could not inspect command '{cmd_name}': {exc}")
+```
+
+Note: `warnings` here is the local list variable returned by `_discover_migrations()`, not the stdlib module (which is not imported in `cache.py`).
+
+Add a test that injects a broken command class and verifies the warning appears:
+
+```python
+@pytest.mark.django_db
+def test_build_cache_warns_for_uninspectable_command(monkeypatch):
+    original_load = management.load_command_class
+
+    def broken_load(app_name, cmd_name):
+        if cmd_name == "migrate":
+            raise RuntimeError("simulated import failure")
+        return original_load(app_name, cmd_name)
+
+    monkeypatch.setattr(management, "load_command_class", broken_load)
+    data = build_cache()
+
+    assert any("migrate" in w and "simulated import failure" in w for w in data["warnings"])
+    assert data["command_options"]["migrate"] == []
+    assert "migrate" in data["commands"]  # still discovered via get_commands()
+```
+
+**Acceptance criteria:**
+- A command whose class raises on load produces a non-empty `warnings` entry containing the command name and exception text.
+- The command still appears in `data["commands"]` (it was discovered by `get_commands()`), but `command_options[cmd_name]` is `[]`.
+- `autocomplete status --verbose` surfaces the warning (no code change needed — it already renders `data["warnings"]`).
+- `uv run pytest tests/test_cache.py -q` passes.
+- `uv run ruff check src/django_completion/cache.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.3-3 — Make the auto-refresh hook testable; replace `warnings.warn` with logging
+
+**Goal:** The monkey-patch in `apps.py` — which fires after every manage.py command — is the core runtime mechanism of the package, yet it has zero unit test coverage. Extract the hook logic into a named module-level function so it can be tested directly. Replace `warnings.warn` (which in a background thread points to `threading.Thread.run`, not a useful frame, and goes to `stderr` where users never see it) with `logging.getLogger("django_completion")`.
+
+**Files:**
+- `src/django_completion/apps.py` — extract two module-level helpers; replace `warnings.warn`
+- `tests/test_apps.py` — new test file
+
+**What to implement:**
+
+Extract two module-level functions (currently closures inside `ready()`):
+
+```python
+import logging
+
+_logger = logging.getLogger("django_completion")
+
+
+def _refresh_safely() -> None:
+    try:
+        from django_completion.cache import maybe_refresh_cache
+        maybe_refresh_cache()
+    except Exception as exc:
+        _logger.warning("cache refresh failed: %s", exc)
+
+
+def _make_execute_hook(original_execute, refresh_fn):
+    """Return a patched BaseCommand.execute that calls refresh_fn in a background thread."""
+    def patched(cmd_self, *args, **kwargs):
+        try:
+            return original_execute(cmd_self, *args, **kwargs)
+        finally:
+            from django.conf import settings
+            if getattr(settings, "DJANGO_COMPLETION_AUTO_REFRESH", True):
+                thread = threading.Thread(target=refresh_fn, name="django-completion-refresh")
+                thread.start()
+    return patched
+```
+
+Update `ready()` to use them:
+
+```python
+def ready(self):
+    from django.core.management.base import BaseCommand
+
+    base_command = cast(Any, BaseCommand)
+    if getattr(base_command, "_django_completion_patched", False):
+        return
+
+    original_execute = BaseCommand.execute
+    base_command.execute = _make_execute_hook(original_execute, _refresh_safely)
+    base_command._django_completion_patched = True
+```
+
+Remove `import warnings` from the module (no longer needed).
+
+**Test coverage in `tests/test_apps.py`:**
+
+Use `threading.Event` to synchronize with the background thread; do not use `time.sleep`.
+
+```python
+import threading
+import pytest
+
+from django_completion.apps import _make_execute_hook, _refresh_safely
+
+
+def test_hook_calls_refresh_fn_after_execute(settings):
+    settings.DJANGO_COMPLETION_AUTO_REFRESH = True
+    called = threading.Event()
+    hook = _make_execute_hook(lambda self, *a, **kw: "result", lambda: called.set())
+    result = hook(None)
+    assert called.wait(timeout=1), "refresh_fn was not called"
+    assert result == "result"
+
+
+def test_hook_skips_refresh_when_disabled(settings):
+    settings.DJANGO_COMPLETION_AUTO_REFRESH = False
+    called = threading.Event()
+    hook = _make_execute_hook(lambda self, *a, **kw: None, lambda: called.set())
+    hook(None)
+    assert not called.wait(timeout=0.1), "refresh_fn should not have been called"
+
+
+def test_hook_fires_refresh_even_when_execute_raises(settings):
+    settings.DJANGO_COMPLETION_AUTO_REFRESH = True
+    called = threading.Event()
+
+    def raising_execute(self, *a, **kw):
+        raise RuntimeError("command failed")
+
+    hook = _make_execute_hook(raising_execute, lambda: called.set())
+    with pytest.raises(RuntimeError, match="command failed"):
+        hook(None)
+    assert called.wait(timeout=1), "refresh_fn should fire even after execute raises"
+
+
+def test_refresh_safely_does_not_propagate_exceptions(monkeypatch):
+    from django_completion import cache
+    monkeypatch.setattr(cache, "maybe_refresh_cache", lambda: (_ for _ in ()).throw(RuntimeError("oops")))
+    _refresh_safely()  # must not raise
+
+
+def test_refresh_safely_logs_exception(monkeypatch, caplog):
+    import logging
+    from django_completion import cache
+    monkeypatch.setattr(cache, "maybe_refresh_cache", lambda: (_ for _ in ()).throw(RuntimeError("oops")))
+    with caplog.at_level(logging.WARNING, logger="django_completion"):
+        _refresh_safely()
+    assert "oops" in caplog.text
+```
+
+**Acceptance criteria:**
+- `_make_execute_hook` and `_refresh_safely` exist at module level in `apps.py`.
+- `import warnings` is removed from `apps.py`; `logging.getLogger("django_completion")` is used instead.
+- `ready()` uses `_make_execute_hook` and `_refresh_safely`.
+- All five tests above pass.
+- `uv run pytest -q` passes (full suite).
+- `uv run ty check` passes.
+
+**Notes:**
+- `_refresh_safely` imports `maybe_refresh_cache` lazily (inside the function) to match the existing pattern and avoid a circular import at module load time.
+- The background thread is intentionally not joined — commands must not block on cache refresh. Tests use `threading.Event.wait(timeout=1)` instead.
+
+---
+
+## Issue 0.2.3-4 — Fix `_migration_app_labels` duplicating `_app_labels` parsing
+
+**Goal:** `_migration_app_labels` rebuilds an `origin_lookup` dict by re-parsing `cache["app_labels"]` inline — the same defensive parsing already done by `_app_labels(cache)`. Concentrate cache-entry access in `_app_labels`; let `_migration_app_labels` consume its output.
+
+**Files:**
+- `src/django_completion/_complete.py` — update `_migration_app_labels`
+
+**What to implement:**
+
+Replace the inline origin-lookup construction in `_migration_app_labels`:
+
+```python
+# before — re-parses cache["app_labels"] independently
+origin_lookup: dict[str, str] = {}
+for entry in cache.get("app_labels", []):
+    if isinstance(entry, dict):
+        label = entry.get("label")
+        if isinstance(label, str) and label:
+            origin = entry.get("origin")
+            origin_lookup[label] = origin if isinstance(origin, str) and origin else "pip"
+```
+
+with:
+
+```python
+# after — reuses the parsing already in _app_labels
+origin_lookup = {label: origin for label, origin in _app_labels(cache)}
+```
+
+`_app_labels` applies identical validation (isinstance checks, empty-string filtering, "pip" default) so the result is the same.
+
+**Acceptance criteria:**
+- All existing `tests/test_complete.py` tests pass unchanged — they already exercise the ordering and filtering behaviour.
+- No new tests required.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+# 0.2.5 Issues
+
+Four fixes and UX improvements surfaced during real-world testing. All are independent.
+
+---
+
+## Issue 0.2.5-1 — Fix shell detection + show source reminder after script update
+
+**Goal:** `autocomplete install` correctly detects zsh when `$SHELL` doesn't reflect the running shell, and always reminds the user to source their rc file when the script was (re)written.
+
+**Root cause 1:** `_detect_shell()` reads `$SHELL`, which reflects the user's login shell, not the currently running shell. A user whose login shell is bash but who runs in zsh gets bash detection. `$ZSH_VERSION` and `$BASH_VERSION` are set by the shell itself and are reliable.
+
+**Root cause 2:** When the hook is already in the rc file, `_install()` prints `"Completion already installed in ~/.zshrc"` but does not remind the user to source. The script file is always rewritten — if it changed, the user needs to source to pick up the update.
+
+**Files:**
+- `src/django_completion/management/commands/autocomplete.py` — `_detect_shell`, `_install`
+
+**What to implement:**
+
+Update `_detect_shell()`:
+```python
+def _detect_shell() -> Literal["zsh", "bash"]:
+    if os.environ.get("BASH_VERSION"):
+        return "bash"
+    if os.environ.get("ZSH_VERSION"):
+        return "zsh"
+    shell = os.environ.get("SHELL", "")
+    return "zsh" if "zsh" in shell else "bash"
+```
+
+**Note:** The original implementation above had the check order reversed (`ZSH_VERSION` before `BASH_VERSION`), which caused a regression fixed in 0.2.6. See Issue 0.2.6-1.
+
+Update `_install()`: when the hook is already present, still print a source reminder after rewriting the script:
+```
+Script updated. To apply changes in your current session, run:
+  source ~/.zshrc
+```
+
+**Acceptance criteria:**
+- With `ZSH_VERSION` set in environment, `_detect_shell()` returns `"zsh"` regardless of `$SHELL`.
+- With `BASH_VERSION` set and `ZSH_VERSION` absent, returns `"bash"`.
+- `autocomplete install` run a second time (hook already present) prints a source reminder.
+- `uv run pytest tests/ -q` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.5-2 — `autocomplete` subcommand completion + status color + subparser descriptions
+
+**Goal:** Three small UX improvements bundled together: (1) shell completion offers `--verbose` for `autocomplete status` and `--shell bash/zsh` for `autocomplete install`; (2) `installed` / `not installed` labels in status output are colorized; (3) each subcommand's own `--help` shows a description line.
+
+**Files:**
+- `src/django_completion/_complete.py` — extend `autocomplete` special case
+- `src/django_completion/management/commands/autocomplete.py` — `_status`, `_status_verbose`, `add_arguments`
+
+**What to implement:**
+
+In `_complete.py`, extend the `autocomplete` pos-2 special case to also handle pos 3:
+- `autocomplete status <TAB>` (pos 3, cur starts with `-`) → `["--verbose"]`
+- `autocomplete install --<TAB>` (pos 3, cur starts with `-`) → `["--shell"]`
+- `autocomplete install --shell <TAB>` (pos 4, not a dash) → `["bash", "zsh"]`
+
+In `autocomplete.py`:
+- Wrap `"installed"` with `self.style.SUCCESS` and `"not installed"` with `self.style.WARNING` in both `_status()` and `_write_verbose_hook_status()` / `_write_verbose_script_status()`.
+- Add `description=` to each `add_parser()` call so the subcommand's own `--help` shows a summary line.
+
+**Acceptance criteria:**
+- `["manage.py", "autocomplete", "status", "--"]`, cword=3 → `["--verbose"]`.
+- `["manage.py", "autocomplete", "install", "--"]`, cword=3 → `["--shell"]`.
+- `["manage.py", "autocomplete", "install", "--shell", ""]`, cword=4 → `["bash", "zsh"]`.
+- `autocomplete status` output shows `installed` in green and `not installed` in yellow.
+- `python manage.py autocomplete status --help` shows a description line above the options.
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.5-3 — Suppress bash file-completion fallback when in manage.py context
+
+**Goal:** `python manage.py makemigrations <TAB>` (and any other command where the helper returns no candidates) shows nothing instead of falling back to filename completion and dumping every file in the project directory.
+
+**Root cause:** The bash template registers `python` with `complete -o default`. When `COMPREPLY` is empty, bash falls back to filename completion. This is intentional for the plain `python <file>` case but harmful once a `manage.py` token is present in the words.
+
+**Files:**
+- `src/django_completion/scripts/bash_completion.sh.tmpl`
+
+**What to implement:**
+
+In `_django_complete_with_helper`, after locating the cache file, use `compopt +o default` to disable the filename fallback when a manage.py token is present in the current words:
+
+```bash
+_django_complete_with_helper() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local cache_file
+    cache_file="$(_django_manage_find_cache)"
+    [[ -z "$cache_file" ]] && return 0
+
+    # Check whether a manage.py token appears before the word being completed.
+    # If so, suppress filename fallback — we own this completion context.
+    local word
+    for word in "${COMP_WORDS[@]::$COMP_CWORD}"; do
+        if [[ "$word" == *manage.py ]]; then
+            compopt +o default 2>/dev/null
+            break
+        fi
+    done
+
+    local words_json
+    ...
+}
+```
+
+`compopt +o default` is a no-op on bash < 4 (where the builtin doesn't exist) — the `2>/dev/null` suppresses the error silently.
+
+**Acceptance criteria:**
+- `python manage.py makemigrations <TAB>` with no local apps in cache → empty completion, no filename listing.
+- `python manage.py <unknown_command> <TAB>` → empty completion, no filename listing.
+- `python <file> <TAB>` (no manage.py token) → filename completion still works (unaffected).
+- `uv run pytest tests/test_shell.py -q` passes.
+
+---
+
+## Issue 0.2.5-4 — Diagnose: "did you mean?" missing for wrong `autocomplete` subcommands
+
+**Goal:** Understand why `python manage.py autocomplete states` does not show a "did you mean?" suggestion, despite Django having built-in command suggestion. Reproduce the behaviour, identify root cause, and either fix it or document the limitation.
+
+**Context:** Django's `execute_from_command_line` shows "did you mean?" for unknown top-level commands (e.g. `migarte` → "did you mean migrate?"). However, for subcommands of a management command (e.g. `autocomplete states`), the error is delegated to argparse, which shows valid choices but not a fuzzy suggestion. The old `fuzzy.py` module was deleted in 0.2.3-1 because it had no call site.
+
+**Files:**
+- Investigation only at first; fix location TBD after diagnosis.
+
+**What to investigate:**
+1. Confirm that `python manage.py autocomplete states` shows `error: argument subcommand: invalid choice: 'states' (choose from install, status, refresh, uninstall)` with no "did you mean?".
+2. Check whether Django's suggestion mechanism could intercept subparser errors.
+3. Decide: add a custom argparse error handler inside `Command.add_arguments` / `Command.handle`, or document that subcommand typos are out of scope.
+
+**Acceptance criteria (after diagnosis):**
+- Root cause is documented in the issue or PR description.
+- Either: `autocomplete states` shows "did you mean status?", or the limitation is added to `docs/troubleshooting.md`.
+- `uv run pytest tests/ -q` passes.
+- `uv run ty check` passes.
+
+---
+
+# 0.2.6 Issues
+
+One regression fix surfaced during real-world testing of 0.2.5.
+
+---
+
+## Issue 0.2.6-1 — Fix shell detection priority: `$BASH_VERSION` before `$ZSH_VERSION`
+
+**Goal:** `autocomplete install` correctly detects bash when bash is spawned inside a running zsh session.
+
+**Root cause:** 0.2.5 introduced `$ZSH_VERSION` / `$BASH_VERSION` detection to replace the unreliable `$SHELL` fallback. However, the check order was wrong: `$ZSH_VERSION` was checked first. When bash is spawned inside zsh, it inherits `$ZSH_VERSION` from the parent process but also sets its own `$BASH_VERSION`. With the old order, the inherited `$ZSH_VERSION` won, causing `autocomplete install` to target `.zshrc` from a bash session.
+
+Observed symptom:
+
+```
+$ echo $0
+/bin/bash
+$ python manage.py autocomplete install
+Completion already installed in /home/user/.zshrc   # wrong shell
+```
+
+**Files:**
+- `src/django_completion/management/commands/autocomplete.py` — `_detect_shell`
+- `tests/test_autocomplete.py` — new regression test
+
+**What to implement:**
+
+Swap the check order in `_detect_shell()` so `$BASH_VERSION` takes precedence:
+
+```python
+def _detect_shell() -> Literal["zsh", "bash"]:
+    if os.environ.get("BASH_VERSION"):   # checked first — cannot be stale
+        return "bash"
+    if os.environ.get("ZSH_VERSION"):
+        return "zsh"
+    shell = os.environ.get("SHELL", "")
+    return "zsh" if "zsh" in shell else "bash"
+```
+
+Rationale: `$BASH_VERSION` is always set by the currently running bash process. It cannot be a stale inherited value from a non-bash parent, because zsh never sets `$BASH_VERSION`. The reverse is not true — `$ZSH_VERSION` can be inherited by a bash child from a parent zsh.
+
+**Regression test:**
+
+```python
+def test_detect_shell_bash_wins_when_both_set(monkeypatch):
+    """bash spawned inside zsh inherits $ZSH_VERSION — $BASH_VERSION must win."""
+    monkeypatch.setenv("ZSH_VERSION", "5.9.0")   # inherited from parent zsh
+    monkeypatch.setenv("BASH_VERSION", "5.2.21")  # set by the running bash
+    monkeypatch.setenv("SHELL", "/usr/bin/zsh")
+    assert _detect_shell() == "bash"
+```
+
+**Acceptance criteria:**
+- `_detect_shell()` returns `"bash"` when both `$ZSH_VERSION` and `$BASH_VERSION` are set.
+- `_detect_shell()` returns `"zsh"` when only `$ZSH_VERSION` is set.
+- `_detect_shell()` returns `"bash"` when only `$BASH_VERSION` is set.
+- `uv run pytest tests/test_autocomplete.py -q` passes.
+- `uv run ty check` passes.
+
+---
+
+# 0.2.8 Issues
+
+One UX improvement to `autocomplete refresh` output and three independent architecture refactors. All are AFK. No ordering dependency between them — each can be grabbed in any order.
+
+---
+
+## Issue 0.2.8-1 — `autocomplete refresh` shows count delta and warning summary
+
+**Goal:** `autocomplete refresh` output shows how many commands/apps changed versus the previous cache, and surfaces the warning count when warnings are present so users know to investigate.
+
+**Root cause:** Currently outputs `Cache rebuilt: 96 commands, 71 apps` — total counts only. After adding a new app to `INSTALLED_APPS` or installing a package with management commands, there is no confirmation the rebuild picked up the change. Warnings from uninspectable commands (e.g. third-party packages incompatible with the current Python/Django version) are also silently absent from the output, so users don't know to run `status --verbose`.
+
+**Files:**
+- `src/django_completion/management/commands/autocomplete.py` — add `_format_delta`, update `_refresh()`
+- `tests/test_autocomplete.py` — new tests
+
+**What to implement:**
+
+Add a small helper:
+
+```python
+def _format_delta(new: int, old: int | None) -> str:
+    if old is None or new == old:
+        return ""
+    diff = new - old
+    return f" ({'+' if diff > 0 else ''}{diff})"
+```
+
+Update `_refresh()` to read the old cache before rebuilding, compute deltas, and append a warning hint when warnings exist:
+
+```python
+def _refresh(self, options: dict[str, Any]) -> None:
+    from django_completion.cache import _cache_path, build_cache, read_cache, write_cache
+
+    cache_path = _cache_path()
+    old = read_cache(cache_path)
+    data = build_cache()
+    write_cache(data, cache_path)
+
+    cmd_count = len(data["commands"])
+    app_count = len(data["app_labels"])
+    cmd_delta = _format_delta(cmd_count, len(old["commands"]) if old else None)
+    app_delta = _format_delta(app_count, len(old["app_labels"]) if old else None)
+
+    warning_count = len(data.get("warnings", []))
+    warning_suffix = (
+        f" — {warning_count} warning{'s' if warning_count != 1 else ''}"
+        f" (run autocomplete status --verbose for details)"
+        if warning_count else ""
+    )
+
+    self.stdout.write(
+        self.style.SUCCESS(
+            f"Cache rebuilt: {cmd_count} commands{cmd_delta}, {app_count} apps{app_delta}{warning_suffix}"
+        )
+    )
+```
+
+Output examples:
+```
+Cache rebuilt: 96 commands (+2), 71 apps (+1)
+Cache rebuilt: 96 commands, 71 apps
+Cache rebuilt: 96 commands, 71 apps — 18 warnings (run autocomplete status --verbose for details)
+Cache rebuilt: 96 commands (+2), 71 apps — 3 warnings (run autocomplete status --verbose for details)
+```
+
+When there is no prior cache (first-ever build), delta suffixes are omitted entirely.
+
+**Acceptance criteria:**
+- `_format_delta(98, 96)` → `" (+2)"`.
+- `_format_delta(95, 96)` → `" (-1)"`.
+- `_format_delta(96, 96)` → `""`.
+- `_format_delta(96, None)` → `""`.
+- After adding a new app to `INSTALLED_APPS` and running refresh, output contains `(+1)` next to apps count.
+- After a second refresh with no change, output shows totals only (no delta suffix).
+- With warnings in the built cache, output contains `N warning(s) (run autocomplete status --verbose for details)`.
+- With zero warnings, output contains no warning suffix.
+- With no prior cache on disk, output shows totals only (no delta suffix).
+- `uv run pytest tests/test_autocomplete.py -q` passes.
+- `uv run ruff check src/django_completion/management/commands/autocomplete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.8-2 — Extract `_collect_commands()` from `build_cache()`
+
+**Goal:** `build_cache()` currently merges two independent data-collection operations — command introspection and migration discovery — into one function. Extract command introspection into `_collect_commands()`, parallel to the existing `_discover_migrations()`, so each concern is independently testable.
+
+**Root cause:** The command introspection loop (loading every command class, parsing argparse options, collecting help text) is inline in `build_cache()` alongside migration discovery. To test that a broken command class produces a warning, the test must monkeypatch `management.load_command_class` inside a full `build_cache()` call — which also triggers migration discovery. There is no seam at which command introspection can be tested alone.
+
+**Files:**
+- `src/django_completion/cache.py` — extract `_collect_commands()`, update `build_cache()`
+- `tests/test_cache.py` — add focused tests for `_collect_commands()`
+
+**What to implement:**
+
+Extract the command introspection loop from `build_cache()` into:
+
+```python
+def _collect_commands(
+    commands_map: dict[str, str],
+) -> tuple[dict[str, str], dict[str, list[str]], dict[str, dict[str, str]], list[str]]:
+    """Inspect each command class and collect help text, options, and warnings.
+
+    Returns (command_help, command_options, command_option_descriptions, warnings).
+    """
+    command_help: dict[str, str] = {}
+    command_options: dict[str, list[str]] = {}
+    command_option_descriptions: dict[str, dict[str, str]] = {}
+    warnings: list[str] = []
+
+    for cmd_name, app_name in commands_map.items():
+        try:
+            cmd = management.load_command_class(app_name, cmd_name)
+            command_help[cmd_name] = cmd.help or ""
+            parser = cmd.create_parser("manage.py", cmd_name)
+            opts: list[str] = []
+            option_descriptions: dict[str, str] = {}
+            for action in parser._actions:
+                opts.extend(s for s in action.option_strings if s.startswith("-"))
+                help_text = "" if action.help is None else str(action.help)
+                for opt in action.option_strings:
+                    if opt.startswith("-"):
+                        option_descriptions[opt] = help_text
+            command_options[cmd_name] = sorted(set(opts))
+            command_option_descriptions[cmd_name] = {
+                opt: option_descriptions.get(opt, "") for opt in command_options[cmd_name]
+            }
+        except Exception as exc:
+            command_help[cmd_name] = ""
+            command_options[cmd_name] = []
+            command_option_descriptions[cmd_name] = {}
+            warnings.append(f"Could not inspect command '{cmd_name}': {exc}")
+
+    return command_help, command_options, command_option_descriptions, warnings
+```
+
+Update `build_cache()` to call both collectors and merge their warnings:
+
+```python
+def build_cache() -> dict:
+    commands_map = management.get_commands()
+    command_names = sorted(commands_map.keys())
+
+    app_configs = list(apps.get_app_configs())
+    app_labels = [{"label": cfg.label, "origin": classify_app(cfg)} for cfg in app_configs]
+    app_labels.sort(key=lambda entry: (entry["origin"] != "local", entry["label"]))
+
+    migration_modules = getattr(settings, "MIGRATION_MODULES", {}) or {}
+    migrations, migration_warnings = _discover_migrations(app_configs, migration_modules)
+
+    command_help, command_options, command_option_descriptions, command_warnings = _collect_commands(commands_map)
+
+    return {
+        "schema_version": 2,
+        "commands": command_names,
+        "app_labels": app_labels,
+        "command_help": command_help,
+        "command_options": command_options,
+        "command_option_descriptions": command_option_descriptions,
+        "migrations": migrations,
+        "warnings": migration_warnings + command_warnings,
+        "generated_at": time.time(),
+    }
+```
+
+Add targeted tests that call `_collect_commands()` directly without triggering migration discovery:
+
+```python
+def test_collect_commands_returns_four_dicts():
+    from django.core import management as mgmt
+    commands_map = mgmt.get_commands()
+    help_, options, descriptions, warnings = _collect_commands(commands_map)
+    assert isinstance(help_, dict)
+    assert isinstance(options, dict)
+    assert isinstance(descriptions, dict)
+    assert isinstance(warnings, list)
+    assert "migrate" in help_
+
+
+def test_collect_commands_warns_for_broken_class(monkeypatch):
+    from django.core import management as mgmt
+    original = mgmt.load_command_class
+
+    def broken(app_name, cmd_name):
+        if cmd_name == "migrate":
+            raise RuntimeError("simulated failure")
+        return original(app_name, cmd_name)
+
+    monkeypatch.setattr(mgmt, "load_command_class", broken)
+    _, options, _, warnings = _collect_commands(mgmt.get_commands())
+    assert any("migrate" in w and "simulated failure" in w for w in warnings)
+    assert options["migrate"] == []
+```
+
+**Acceptance criteria:**
+- `_collect_commands()` exists as a module-level function in `cache.py`.
+- `build_cache()` calls `_collect_commands()` and `_discover_migrations()` separately, merging their warning lists.
+- `build_cache()` output is identical to before (no behavior change).
+- The two new tests above pass without `@pytest.mark.django_db` on the `_collect_commands()` test (migration discovery is not triggered).
+- `uv run pytest tests/test_cache.py -q` passes.
+- `uv run ruff check src/django_completion/cache.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.8-3 — Replace `_positional_candidates()` if-chain with command rule registry
+
+**Goal:** The routing logic in `_positional_candidates()` is a sequence of `if cmd ==` branches. Replace it with a declarative registry so that adding a new command's completion behavior is a data entry, not a code edit inside the routing function.
+
+**Root cause:** Every new command-specific completion rule requires editing `_positional_candidates()` (and sometimes `_APP_LABEL_COMMANDS`) in a different place. The pattern repeats across Issues 0.2.2-2 through 0.2.2-4, and will repeat again for any future command-specific rule. There is no single place to look up what a given command completes.
+
+**Files:**
+- `src/django_completion/_complete.py` — define `CommandRule`, build `_COMMAND_RULES`, replace if-chain
+- `tests/test_complete.py` — add registry tests; all existing tests must pass unchanged
+
+**What to implement:**
+
+Define a small descriptor. Keep it as a frozen dataclass or TypedDict — no callable fields, just declarative labels so the registry can be read as a table:
+
+```python
+from dataclasses import dataclass
+
+_Pos = str  # "migration_apps" | "local_apps" | "all_apps" | "migration_names" | "migration_names_no_zero" | "options"
+
+@dataclass(frozen=True)
+class CommandRule:
+    pos2: _Pos = "options"
+    pos3: _Pos = "options"
+```
+
+Build the registry. `_APP_LABEL_COMMANDS` folds in as the `"all_apps"` group:
+
+```python
+_COMMAND_RULES: dict[str, CommandRule] = {
+    "migrate":         CommandRule(pos2="migration_apps", pos3="migration_names"),
+    "showmigrations":  CommandRule(pos2="migration_apps", pos3="options"),
+    "sqlmigrate":      CommandRule(pos2="migration_apps", pos3="migration_names_no_zero"),
+    "makemigrations":  CommandRule(pos2="local_apps",     pos3="options"),
+    "check":           CommandRule(pos2="all_apps",        pos3="options"),
+    "dumpdata":        CommandRule(pos2="all_apps",        pos3="options"),
+    "test":            CommandRule(pos2="all_apps",        pos3="options"),
+}
+```
+
+Replace the if-chain in `_positional_candidates()` with a registry lookup. The `autocomplete` special case (hardcoded subcommands not in the cache) stays as-is — it is not cache-driven and does not belong in the registry.
+
+The dispatch for `pos3` of `migrate` / `sqlmigrate` needs the app label from `words[manage_idx + 2]`; pass it through the dispatch as needed.
+
+Remove `_APP_LABEL_COMMANDS` (it is now expressed by the `"all_apps"` entries in the registry).
+
+**Acceptance criteria:**
+- `_COMMAND_RULES` exists as a module-level dict.
+- `_APP_LABEL_COMMANDS` is removed.
+- `_positional_candidates()` dispatches via `_COMMAND_RULES` lookup; the `if cmd in ("migrate", ...)` chain is gone.
+- All existing `tests/test_complete.py` tests pass unchanged — no behavior change.
+- New tests verify registry contents directly:
+  - `_COMMAND_RULES["migrate"].pos2 == "migration_apps"`
+  - `_COMMAND_RULES["migrate"].pos3 == "migration_names"`
+  - `_COMMAND_RULES["makemigrations"].pos2 == "local_apps"`
+  - `_COMMAND_RULES["sqlmigrate"].pos3 == "migration_names_no_zero"`
+  - `"runserver"` not in `_COMMAND_RULES` (falls back to options-only default)
+- `uv run pytest tests/test_complete.py -q` passes.
+- `uv run ruff check src/django_completion/_complete.py` passes.
+- `uv run ty check` passes.
+
+---
+
+## Issue 0.2.8-4 — Add `CacheData` TypedDict
+
+**Goal:** The v2 cache schema is currently defined only by what `build_cache()` returns. Add a `CacheData` TypedDict so the schema has one authoritative home, is discoverable by new contributors, and is statically verifiable.
+
+**Root cause:** Three modules (`cache.py`, `_complete.py`, `autocomplete.py`) all know the cache dict structure via string-keyed `.get()` calls. There is no single place to answer "what fields does the cache have and what are their types?" If a field is added or renamed, the impact must be found by grepping three files. The defensive `isinstance` guards in `_complete.py` protect against malformed on-disk data and stay — the TypedDict is documentation and static safety, not runtime validation.
+
+**Files:**
+- `src/django_completion/cache.py` — add `CacheData` TypedDict, annotate `build_cache()` return type
+- `src/django_completion/_complete.py` — annotate `complete()` and helpers to accept `CacheData`
+- `src/django_completion/management/commands/autocomplete.py` — annotate status helper signatures
+
+**What to implement:**
+
+Add `CacheData` to `cache.py`:
+
+```python
+from typing import TypedDict
+
+class AppLabelEntry(TypedDict):
+    label: str
+    origin: str  # "local" | "pip"
+
+
+class CacheData(TypedDict):
+    schema_version: int
+    commands: list[str]
+    app_labels: list[AppLabelEntry]
+    command_help: dict[str, str]
+    command_options: dict[str, list[str]]
+    command_option_descriptions: dict[str, dict[str, str]]
+    migrations: dict[str, list[str]]
+    warnings: list[str]
+    generated_at: float
+```
+
+Update `build_cache()` return annotation:
+
+```python
+def build_cache() -> CacheData:
+    ...
+```
+
+`read_cache()` returns `dict | None` (not `CacheData | None`) because on-disk data may be a v1 cache or otherwise malformed. Do not change its return type — callers that need a typed view are responsible for the version check.
+
+Update `_complete.py` function signatures to accept `CacheData | dict[str, Any]` — or simply `dict[str, Any]` with a comment pointing to `CacheData`. Do not remove the defensive `isinstance` guards; they protect against on-disk corruption.
+
+Update status helper signatures in `autocomplete.py` to accept `CacheData | dict[str, Any]`.
+
+No behavior changes anywhere. This issue is annotation-only.
+
+**Acceptance criteria:**
+- `CacheData` and `AppLabelEntry` exist in `cache.py` and are importable.
+- `build_cache()` return type annotation is `CacheData`.
+- `uv run ty check` passes with no new errors.
+- `uv run pytest -q` passes (no behavior change).
+- `uv run ruff check .` passes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-completion"
-version = "0.2.7"
+version = "0.2.8"
 description = "Tab completion for Django's manage.py — commands, app labels, options, and migration targets in bash and zsh"
 readme = "README.md"
 authors = [

--- a/src/django_completion/_complete.py
+++ b/src/django_completion/_complete.py
@@ -3,12 +3,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 # See cache.CacheData for the full v2 cache schema.
 _CacheT = dict[str, Any]
 
-_Pos = str  # "migration_apps" | "local_apps" | "all_apps" | "migration_names" | "migration_names_no_zero" | "options"
+_Pos = Literal["migration_apps", "local_apps", "all_apps", "migration_names", "migration_names_no_zero", "options"]
 
 
 @dataclass(frozen=True)

--- a/src/django_completion/_complete.py
+++ b/src/django_completion/_complete.py
@@ -1,24 +1,36 @@
 import argparse
 from collections.abc import Sequence
+from dataclasses import dataclass
 import json
 from pathlib import Path
 from typing import Any
 
-# Commands known to accept app labels as positional arguments.
-# Commands not in this set fall back to options-only completion.
-_APP_LABEL_COMMANDS = frozenset(
-    {
-        "check",
-        "dumpdata",
-        "migrate",
-        "showmigrations",
-        "sqlmigrate",
-        "test",
-    }
-)
+# See cache.CacheData for the full v2 cache schema.
+_CacheT = dict[str, Any]
+
+_Pos = str  # "migration_apps" | "local_apps" | "all_apps" | "migration_names" | "migration_names_no_zero" | "options"
 
 
-def _load_cache(path: str) -> dict[str, Any] | None:
+@dataclass(frozen=True)
+class CommandRule:
+    pos2: _Pos = "options"
+    pos3: _Pos = "options"
+
+
+# Declarative completion rules per command. Commands absent from this registry
+# fall back to options-only completion (safe default for unknown/custom commands).
+_COMMAND_RULES: dict[str, CommandRule] = {
+    "migrate": CommandRule(pos2="migration_apps", pos3="migration_names"),
+    "showmigrations": CommandRule(pos2="migration_apps", pos3="options"),
+    "sqlmigrate": CommandRule(pos2="migration_apps", pos3="migration_names_no_zero"),
+    "makemigrations": CommandRule(pos2="local_apps", pos3="options"),
+    "check": CommandRule(pos2="all_apps", pos3="options"),
+    "dumpdata": CommandRule(pos2="all_apps", pos3="options"),
+    "test": CommandRule(pos2="all_apps", pos3="options"),
+}
+
+
+def _load_cache(path: str) -> _CacheT | None:
     """Read a completion cache from disk, returning None when it is unavailable."""
     try:
         data = json.loads(Path(path).read_text())
@@ -33,7 +45,7 @@ def _manage_index(words: list[str], cword: int) -> int | None:
     return indexes[-1] if indexes else None
 
 
-def _app_labels(cache: dict[str, Any]) -> list[tuple[str, str]]:
+def _app_labels(cache: _CacheT) -> list[tuple[str, str]]:
     """Return cached app labels with their origin in cache order."""
     labels: list[tuple[str, str]] = []
 
@@ -48,7 +60,7 @@ def _app_labels(cache: dict[str, Any]) -> list[tuple[str, str]]:
     return labels
 
 
-def _migration_app_labels(cache: dict[str, Any]) -> list[tuple[str, str]]:
+def _migration_app_labels(cache: _CacheT) -> list[tuple[str, str]]:
     """Return app labels that have migrations, local apps first then others alphabetically."""
     migrations = cache.get("migrations")
     if not isinstance(migrations, dict):
@@ -66,7 +78,7 @@ def _migration_app_labels(cache: dict[str, Any]) -> list[tuple[str, str]]:
     return result
 
 
-def _options(cache: dict[str, Any], cmd: str | None) -> list[str]:
+def _options(cache: _CacheT, cmd: str | None) -> list[str]:
     """Return cached option strings for a command."""
     command_options = cache.get("command_options", {})
     if not isinstance(cmd, str) or not isinstance(command_options, dict):
@@ -78,12 +90,12 @@ def _options(cache: dict[str, Any], cmd: str | None) -> list[str]:
     return [opt for opt in opts if isinstance(opt, str) and opt]
 
 
-def _local_app_labels(cache: dict[str, Any]) -> list[str]:
+def _local_app_labels(cache: _CacheT) -> list[str]:
     """Return app labels where origin is 'local', alphabetically sorted."""
     return sorted(label for label, origin in _app_labels(cache) if origin == "local")
 
 
-def _migration_names(cache: dict[str, Any], app_label: str | None, *, include_zero: bool = True) -> list[str]:
+def _migration_names(cache: _CacheT, app_label: str | None, *, include_zero: bool = True) -> list[str]:
     """Return cached migration names for an app, optionally including the zero target."""
     migrations = cache.get("migrations")
     if not isinstance(app_label, str) or not isinstance(migrations, dict):
@@ -110,7 +122,7 @@ def _format_candidates(candidates: Sequence[tuple[str, str | None]], fmt: str) -
     return [value for value, _description in candidates if value]
 
 
-def _command_candidates(cache: dict[str, Any]) -> list[tuple[str, str]]:
+def _command_candidates(cache: _CacheT) -> list[tuple[str, str]]:
     """Return command candidates with help descriptions."""
     command_help = cache.get("command_help", {})
     if not isinstance(command_help, dict):
@@ -120,7 +132,7 @@ def _command_candidates(cache: dict[str, Any]) -> list[tuple[str, str]]:
     return [(cmd_name, command_help.get(cmd_name, "")) for cmd_name in commands]
 
 
-def _option_candidates(cache: dict[str, Any], cmd: str | None) -> list[tuple[str, str]]:
+def _option_candidates(cache: _CacheT, cmd: str | None) -> list[tuple[str, str]]:
     """Return option candidates with descriptions for a command."""
     option_descriptions = cache.get("command_option_descriptions", {})
     if not isinstance(option_descriptions, dict):
@@ -131,45 +143,15 @@ def _option_candidates(cache: dict[str, Any], cmd: str | None) -> list[tuple[str
     return [(opt, descriptions.get(opt, "")) for opt in _options(cache, cmd)]
 
 
-def _app_and_option_candidates(cache: dict[str, Any], cmd: str | None) -> list[tuple[str, str]]:
+def _app_and_option_candidates(cache: _CacheT, cmd: str | None) -> list[tuple[str, str]]:
     """Return v1-style app label and option candidates for a command."""
     candidates = [(label, f"[{origin}]") for label, origin in _app_labels(cache)]
     candidates.extend(_option_candidates(cache, cmd))
     return candidates
 
 
-def _migration_app_label_candidates(cache: dict[str, Any], fmt: str) -> list[str]:
+def _migration_app_label_candidates(cache: _CacheT, fmt: str) -> list[str]:
     return _format_candidates([(label, f"[{origin}]") for label, origin in _migration_app_labels(cache)], fmt)
-
-
-def _migration_command_candidates(
-    cache: dict[str, Any],
-    cmd: str,
-    pos: int,
-    words: list[str],
-    manage_idx: int,
-    fmt: str,
-) -> list[str]:
-    """Handle migrate / showmigrations / sqlmigrate positional completion.
-
-    pos 2          → apps that have migrations (local-first)
-    pos 3, migrate → migration names for the chosen app, including "zero"
-    pos 3, sqlmig  → migration names for the chosen app, excluding "zero"
-    pos 3, showmig → (not reached; showmigrations has no migration-name slot)
-    otherwise      → options only
-    """
-    if pos == 2:
-        return _migration_app_label_candidates(cache, fmt)
-
-    if pos == 3 and cmd == "migrate":
-        app = words[manage_idx + 2] if manage_idx + 2 < len(words) else None
-        return _format_candidates([(name, "") for name in _migration_names(cache, app)], fmt)
-
-    if pos == 3 and cmd == "sqlmigrate":
-        app = words[manage_idx + 2] if manage_idx + 2 < len(words) else None
-        return _format_candidates([(name, "") for name in _migration_names(cache, app, include_zero=False)], fmt)
-
-    return _format_candidates(_option_candidates(cache, cmd), fmt)
 
 
 def _autocomplete_option_candidates(words: list[str], manage_idx: int, pos: int) -> list[tuple[str, str]]:
@@ -183,7 +165,7 @@ def _autocomplete_option_candidates(words: list[str], manage_idx: int, pos: int)
 
 
 def _positional_candidates(
-    cache: dict[str, Any],
+    cache: _CacheT,
     cmd: str | None,
     pos: int,
     words: list[str],
@@ -202,20 +184,25 @@ def _positional_candidates(
             return _format_candidates([("bash", ""), ("zsh", "")], fmt)
         return []
 
-    if cmd == "makemigrations":
+    rule = _COMMAND_RULES.get(cmd) if isinstance(cmd, str) else None
+    slot = (rule.pos2 if pos == 2 else rule.pos3 if pos == 3 else "options") if rule is not None else "options"
+
+    if slot == "migration_apps":
+        return _migration_app_label_candidates(cache, fmt)
+    if slot == "migration_names":
+        app = words[manage_idx + 2] if manage_idx + 2 < len(words) else None
+        return _format_candidates([(name, "") for name in _migration_names(cache, app)], fmt)
+    if slot == "migration_names_no_zero":
+        app = words[manage_idx + 2] if manage_idx + 2 < len(words) else None
+        return _format_candidates([(name, "") for name in _migration_names(cache, app, include_zero=False)], fmt)
+    if slot == "local_apps":
         return _format_candidates([(label, "[local]") for label in _local_app_labels(cache)], fmt)
-
-    if cmd in ("migrate", "showmigrations", "sqlmigrate") and isinstance(cmd, str):
-        return _migration_command_candidates(cache, cmd, pos, words, manage_idx, fmt)
-
-    # Whitelist: commands known to accept app labels get app-label + option completion.
-    # Everything else (runserver, shell, custom commands, etc.) gets options only.
-    if cmd in _APP_LABEL_COMMANDS:
+    if slot == "all_apps":
         return _format_candidates(_app_and_option_candidates(cache, cmd), fmt)
     return _format_candidates(_option_candidates(cache, cmd), fmt)
 
 
-def complete(cache: dict[str, Any], words: list[str], cword: int, fmt: str = "bash") -> list[str]:
+def complete(cache: _CacheT, words: list[str], cword: int, fmt: str = "bash") -> list[str]:
     """Return completion candidates for a tokenized manage.py command line."""
     if cword < 0 or cword >= len(words):
         return []

--- a/src/django_completion/cache.py
+++ b/src/django_completion/cache.py
@@ -1,14 +1,34 @@
+from collections.abc import Mapping
 import importlib.util
 import json
 from pathlib import Path
 import threading
 import time
+from typing import Any, TypedDict
 
 from django.apps import apps
 from django.conf import settings
 from django.core import management
 
 from django_completion.classify import classify_app
+
+
+class AppLabelEntry(TypedDict):
+    label: str
+    origin: str  # "local" | "pip"
+
+
+class CacheData(TypedDict):
+    schema_version: int
+    commands: list[str]
+    app_labels: list[AppLabelEntry]
+    command_help: dict[str, str]
+    command_options: dict[str, list[str]]
+    command_option_descriptions: dict[str, dict[str, str]]
+    migrations: dict[str, list[str]]
+    warnings: list[str]
+    generated_at: float
+
 
 CACHE_FILENAME = ".django-completion-cache.json"
 COOLDOWN_SECONDS = 60
@@ -82,20 +102,18 @@ def _discover_migrations(app_configs, migration_modules: dict) -> tuple[dict[str
     return migrations, warnings
 
 
-def build_cache() -> dict:
-    commands_map = management.get_commands()
-    command_names = sorted(commands_map.keys())
+def _collect_commands(
+    commands_map: dict[str, str],
+) -> tuple[dict[str, str], dict[str, list[str]], dict[str, dict[str, str]], list[str]]:
+    """Inspect each command class and collect help text, options, and warnings.
 
-    app_configs = list(apps.get_app_configs())
-    app_labels = [{"label": cfg.label, "origin": classify_app(cfg)} for cfg in app_configs]
-    app_labels.sort(key=lambda entry: (entry["origin"] != "local", entry["label"]))
-
-    migration_modules = getattr(settings, "MIGRATION_MODULES", {}) or {}
-    migrations, warnings = _discover_migrations(app_configs, migration_modules)
-
-    command_options: dict[str, list[str]] = {}
+    Returns (command_help, command_options, command_option_descriptions, warnings).
+    """
     command_help: dict[str, str] = {}
+    command_options: dict[str, list[str]] = {}
     command_option_descriptions: dict[str, dict[str, str]] = {}
+    warnings: list[str] = []
+
     for cmd_name, app_name in commands_map.items():
         try:
             cmd = management.load_command_class(app_name, cmd_name)
@@ -119,6 +137,22 @@ def build_cache() -> dict:
             command_option_descriptions[cmd_name] = {}
             warnings.append(f"Could not inspect command '{cmd_name}': {exc}")
 
+    return command_help, command_options, command_option_descriptions, warnings
+
+
+def build_cache() -> CacheData:
+    commands_map = management.get_commands()
+    command_names = sorted(commands_map.keys())
+
+    app_configs = list(apps.get_app_configs())
+    app_labels: list[AppLabelEntry] = [{"label": cfg.label, "origin": classify_app(cfg)} for cfg in app_configs]
+    app_labels.sort(key=lambda entry: (entry["origin"] != "local", entry["label"]))
+
+    migration_modules = getattr(settings, "MIGRATION_MODULES", {}) or {}
+    migrations, migration_warnings = _discover_migrations(app_configs, migration_modules)
+
+    command_help, command_options, command_option_descriptions, command_warnings = _collect_commands(commands_map)
+
     return {
         "schema_version": 2,
         "commands": command_names,
@@ -127,12 +161,12 @@ def build_cache() -> dict:
         "command_options": command_options,
         "command_option_descriptions": command_option_descriptions,
         "migrations": migrations,
-        "warnings": warnings,
+        "warnings": migration_warnings + command_warnings,
         "generated_at": time.time(),
     }
 
 
-def write_cache(data: dict, path: Path | None = None) -> None:
+def write_cache(data: Mapping[str, Any], path: Path | None = None) -> None:
     if path is None:
         path = _cache_path()
     path.write_text(json.dumps(data, indent=2))

--- a/src/django_completion/cache.py
+++ b/src/django_completion/cache.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 import threading
 import time
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 from django.apps import apps
 from django.conf import settings
@@ -15,7 +15,7 @@ from django_completion.classify import classify_app
 
 class AppLabelEntry(TypedDict):
     label: str
-    origin: str  # "local" | "pip"
+    origin: Literal["local", "pip"]
 
 
 class CacheData(TypedDict):

--- a/src/django_completion/management/commands/autocomplete.py
+++ b/src/django_completion/management/commands/autocomplete.py
@@ -146,6 +146,14 @@ def _script_status(shell: Literal["bash", "zsh"], package_version: str) -> tuple
     return script_path, script_version, f"outdated (script v{script_version}, package v{package_version})"
 
 
+def _format_delta(new: int, old: int | None) -> str:
+    """Return a parenthesised change string, or empty string when unchanged or no baseline."""
+    if old is None or new == old:
+        return ""
+    diff = new - old
+    return f" ({'+' if diff > 0 else ''}{diff})"
+
+
 def _human_age(seconds: float) -> str:
     """Convert a duration in seconds to a human-readable string."""
     n = int(seconds)
@@ -389,12 +397,30 @@ class Command(BaseCommand):
 
     def _refresh(self, options: dict[str, Any]) -> None:
         """Force a full cache rebuild and persist it to disk."""
-        from django_completion.cache import _cache_path, build_cache, write_cache
+        from django_completion.cache import _cache_path, build_cache, read_cache, write_cache
 
+        cache_path = _cache_path()
+        old = read_cache(cache_path)
         data = build_cache()
-        write_cache(data, _cache_path())
+        write_cache(data, cache_path)
+
+        cmd_count = len(data["commands"])
+        app_count = len(data["app_labels"])
+        cmd_delta = _format_delta(cmd_count, len(old["commands"]) if old else None)
+        app_delta = _format_delta(app_count, len(old["app_labels"]) if old else None)
+
+        warning_count = len(data.get("warnings", []))
+        warning_suffix = (
+            f" — {warning_count} warning{'s' if warning_count != 1 else ''}"
+            f" (run autocomplete status --verbose for details)"
+            if warning_count
+            else ""
+        )
+
         self.stdout.write(
-            self.style.SUCCESS(f"Cache rebuilt: {len(data['commands'])} commands, {len(data['app_labels'])} apps")
+            self.style.SUCCESS(
+                f"Cache rebuilt: {cmd_count} commands{cmd_delta}, {app_count} apps{app_delta}{warning_suffix}"
+            )
         )
 
     def _uninstall(self, options: dict[str, Any]) -> None:

--- a/tests/test_autocomplete.py
+++ b/tests/test_autocomplete.py
@@ -1,5 +1,10 @@
+from io import StringIO
+
+from django.core.management import call_command
 from django.core.management.base import CommandError
 import pytest
+
+from django_completion.management.commands.autocomplete import _format_delta
 
 
 @pytest.mark.django_db
@@ -120,3 +125,61 @@ def test_detect_shell_bash_wins_when_both_set(monkeypatch):
 
     reload(mod)
     assert mod._detect_shell() == "bash"
+
+
+# --- 0.2.8-1: refresh delta output ---
+
+
+def test_format_delta_positive():
+    assert _format_delta(98, 96) == " (+2)"
+
+
+def test_format_delta_negative():
+    assert _format_delta(95, 96) == " (-1)"
+
+
+def test_format_delta_no_change():
+    assert _format_delta(96, 96) == ""
+
+
+def test_format_delta_no_old():
+    assert _format_delta(96, None) == ""
+
+
+@pytest.mark.django_db
+def test_refresh_output_shows_totals(tmp_path, monkeypatch):
+    monkeypatch.setattr("django_completion.management.commands.autocomplete._INSTALL_DIR", tmp_path / "install")
+    monkeypatch.setattr("django_completion.cache.CACHE_FILENAME", str(tmp_path / "cache.json"))
+
+    out = StringIO()
+    call_command("autocomplete", "refresh", stdout=out)
+    output = out.getvalue()
+
+    assert "Cache rebuilt:" in output
+    assert "commands" in output
+    assert "apps" in output
+
+
+@pytest.mark.django_db
+def test_refresh_output_shows_no_delta_on_first_run(tmp_path, monkeypatch):
+    cache_path = tmp_path / "cache.json"
+    monkeypatch.setattr("django_completion.cache.CACHE_FILENAME", str(cache_path))
+
+    out = StringIO()
+    call_command("autocomplete", "refresh", stdout=out)
+    output = out.getvalue()
+
+    # No prior cache → no delta in parentheses
+    assert "(+" not in output
+    assert "(-" not in output
+
+
+@pytest.mark.django_db
+def test_refresh_output_no_warning_suffix_when_no_warnings(tmp_path, monkeypatch, settings):
+    cache_path = tmp_path / "cache.json"
+    monkeypatch.setattr("django_completion.cache.CACHE_FILENAME", str(cache_path))
+
+    out = StringIO()
+    call_command("autocomplete", "refresh", stdout=out)
+
+    assert "warning" not in out.getvalue().lower()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,7 +3,7 @@ import time
 from django.core import management
 import pytest
 
-from django_completion.cache import build_cache, is_stale, read_cache, write_cache
+from django_completion.cache import _collect_commands, build_cache, is_stale, read_cache, write_cache
 
 
 @pytest.mark.django_db
@@ -132,6 +132,33 @@ def test_build_cache_warns_for_uninspectable_command(monkeypatch):
     assert any("migrate" in w and "simulated import failure" in w for w in data["warnings"])
     assert data["command_options"]["migrate"] == []
     assert "migrate" in data["commands"]
+
+
+# --- 0.2.8-2: _collect_commands() ---
+
+
+def test_collect_commands_returns_four_dicts():
+    commands_map = management.get_commands()
+    help_, options, descriptions, warnings = _collect_commands(commands_map)
+    assert isinstance(help_, dict)
+    assert isinstance(options, dict)
+    assert isinstance(descriptions, dict)
+    assert isinstance(warnings, list)
+    assert "migrate" in help_
+
+
+def test_collect_commands_warns_for_broken_class(monkeypatch):
+    original = management.load_command_class
+
+    def broken(app_name, cmd_name):
+        if cmd_name == "migrate":
+            raise RuntimeError("simulated failure")
+        return original(app_name, cmd_name)
+
+    monkeypatch.setattr(management, "load_command_class", broken)
+    _, options, _, warnings = _collect_commands(management.get_commands())
+    assert any("migrate" in w and "simulated failure" in w for w in warnings)
+    assert options["migrate"] == []
 
 
 def test_write_and_read_cache(tmp_path):

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -2,7 +2,7 @@ import json
 import subprocess
 import sys
 
-from django_completion._complete import complete
+from django_completion._complete import _COMMAND_RULES, complete
 
 
 def _run_complete_cli(cache_file, words_json: str, cword: str = "1"):
@@ -505,3 +505,23 @@ def test_autocomplete_refresh_dash_returns_empty():
     # refresh has no subcommand-specific options; fall back to empty
     result = complete(_cache(), ["manage.py", "autocomplete", "refresh", "--"], 3)
     assert result == []
+
+
+# --- 0.2.8-3: command rule registry ---
+
+
+def test_command_rules_migrate():
+    assert _COMMAND_RULES["migrate"].pos2 == "migration_apps"
+    assert _COMMAND_RULES["migrate"].pos3 == "migration_names"
+
+
+def test_command_rules_makemigrations():
+    assert _COMMAND_RULES["makemigrations"].pos2 == "local_apps"
+
+
+def test_command_rules_sqlmigrate():
+    assert _COMMAND_RULES["sqlmigrate"].pos3 == "migration_names_no_zero"
+
+
+def test_command_rules_runserver_absent():
+    assert "runserver" not in _COMMAND_RULES


### PR DESCRIPTION
## Summary

- **`autocomplete refresh` output** now shows `(+N)` / `(-N)` deltas for command and app counts versus the previous cache, and a `— N warning(s) (run autocomplete status --verbose for details)` hint when uninspectable commands exist. No delta on first-ever build or when counts are unchanged.
- **`_collect_commands()` extracted** from `build_cache()` as a standalone function parallel to `_discover_migrations()`. Each returns its own warnings list; `build_cache()` merges them. Command introspection is now testable in isolation without triggering migration discovery.
- **Command rule registry** in `_complete.py`: `_positional_candidates()` if-chain replaced by a declarative `_COMMAND_RULES` dict of frozen `CommandRule` dataclasses (`pos2`/`pos3` slots). `_APP_LABEL_COMMANDS` removed (expressed by `"all_apps"` entries in the registry). `_migration_command_candidates()` removed (dead after registry handles routing).
- **`CacheData` TypedDict** added to `cache.py` alongside `AppLabelEntry`. `build_cache()` annotated `-> CacheData`. `write_cache()` broadened to `Mapping[str, Any]` (required by `ty` — TypedDict is not assignable to bare `dict`).
