### PR TITLE
docs: SEO improvements and JSON-LD schema (0.2.11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,5 +66,8 @@ skills-lock.json
 
 # Internal planning docs
 PLAN.md
-V2_ISSUES.md
-PROMOTION.md
+tmp/V2_ISSUES.md
+tmp/PROMOTION.md
+
+# Dev tools
+cover-image.html

--- a/CHANGELOG/0.2.11.md
+++ b/CHANGELOG/0.2.11.md
@@ -1,0 +1,19 @@
+# 0.2.11
+
+Documentation and SEO improvements. No code or behaviour changes.
+
+## Changes
+
+- **Add SoftwareApplication and WebSite JSON-LD schema to docs homepage**: `overrides/main.html` injects structured data into the `<head>` of the homepage only, making the package machine-readable for AI search engines (ChatGPT, Perplexity, Google AI Overviews). Includes `featureList` and `softwareRequirements` for accurate AI citation.
+
+- **Wire up Zensical template override**: `zensical.toml` now includes `custom_dir = "overrides"` so the schema override is applied at build time.
+
+- **Expand docs/index.md**: Added "How it works" summary (cache → shell hook → no Django import) and "Why not Django's built-in?" explanation. Homepage was previously navigation-only.
+
+- **Add author attribution to all doc pages**: Each page footer now includes author name and last-updated date, improving E-E-A-T signals for search quality raters.
+
+- **Add external links in comparison.md**: `django-admin.bash` links to Django's GitHub source; `argparse.ArgumentParser` links to Python docs. Makes comparison claims verifiable.
+
+- **Automate softwareVersion sync in release script**: `scripts/release.py` now updates `"softwareVersion"` in `overrides/main.html` before tagging, so the JSON-LD schema version never drifts from `pyproject.toml`.
+
+- **Update .gitignore**: Move `PROMOTION.md` and `V2_ISSUES.md` to `tmp/` subdirectory paths; add `cover-image.html` exclusion.

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,3 +136,6 @@ Future rules should preserve these constraints:
 - missing or malformed cache data must fail silently in the shell
 - bash and zsh behavior should be covered by shared helper tests
 - shell templates should not duplicate command-context logic
+
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -6,8 +6,8 @@ Django ships its own shell completion mechanism. This page explains what it prov
 
 Django's completion support comes in two forms:
 
-- A bash completion script (`django-admin.bash`) that system package managers may install automatically. It hooks into bash's completion system and completes command names after `django-admin` and `manage.py`.
-- Argparse's built-in completion integration, available on Python 3.9+ via `argparse.ArgumentParser`. When wired up, it completes option flags for any command.
+- A bash completion script ([`django-admin.bash`](https://github.com/django/django/blob/main/extras/django_bash_completion)) that system package managers may install automatically. It hooks into bash's completion system and completes command names after `django-admin` and `manage.py`.
+- Argparse's built-in completion integration, available on Python 3.9+ via [`argparse.ArgumentParser`](https://docs.python.org/3/library/argparse.html). When wired up, it completes option flags for any command.
 
 Both forms work without installing any additional package.
 
@@ -49,3 +49,6 @@ The built-in mechanism is generic — it reads argparse metadata at completion t
 **Use django-completion** if you work with migrations regularly, manage many apps, or want zsh support with descriptions. The install is one command and the cache refreshes automatically.
 
 **Both can coexist.** django-completion's shell hook activates when a `.django-completion-cache.json` is found in the project directory. For `django-admin` (which django-completion does not support), Django's built-in completion continues to apply.
+
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/docs/how_it_works.md
+++ b/docs/how_it_works.md
@@ -108,3 +108,6 @@ The helper accepts a cache path, shell words, current-word index, and output for
 - removes `~/.local/share/django-completion/` if it is empty
 
 It never touches files outside the managed path.
+
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,6 @@
 # django-completion
 
-Project-aware shell completion for Django's `manage.py`.
-
-Complete commands, app labels, options, and migration targets from your actual Django project.
+**django-completion** adds project-aware tab completion to Django's `manage.py`. It completes command names, app labels, option flags, and migration targets in bash and zsh — reading a local JSON cache so Tab never imports Django or touches the database.
 
 ```bash
 $ python manage.py migrate <TAB>
@@ -36,8 +34,19 @@ $ python manage.py runserver --<TAB>
 | Invocations | `manage.py`, `python manage.py`, `python3 manage.py`, `python ./manage.py`, `uv run python manage.py` |
 | Completion depth | commands, app labels, options, migrate app labels, migration names |
 
+## How it works
+
+django-completion writes a JSON cache (`.django-completion-cache.json`) to your project root when you run `autocomplete install`, then refreshes it in a background thread after each `manage.py` command. When you press Tab, a shell script reads that file — no Python import, no Django startup, no database query. The cache holds management command names, app labels with their pip-or-local origin, option flags per command, and migration file names discovered on disk. Completion stays current without making Tab slow.
+
+## Why not Django's built-in?
+
+Django ships a bash script that completes command names and option flags. It works without any extra package but reads argparse metadata at completion time and has no knowledge of your project's runtime state — so `python manage.py migrate <TAB>` shows nothing, and `python manage.py migrate accounts <TAB>` shows nothing. django-completion fills that gap.
+
+See [Comparison with Django's built-in completion](comparison.md) for the full feature breakdown.
+
 ## Why it exists
 
 Django can suggest close command names after an error. django-completion prevents many of those errors by completing project-specific commands, app labels, options, and migration targets before you press Enter.
 
-See [Comparison with Django's built-in completion](comparison.md) for a feature-by-feature breakdown.
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -99,3 +99,6 @@ git clone https://github.com/soldatov-ss/django-completion.git
 cd django-completion
 uv sync
 ```
+
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -193,3 +193,6 @@ if DEBUG:
 ```
 
 Use the environment switch that matches your deployment setup.
+
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -135,3 +135,6 @@ These are currently out of scope:
 - global options before command, such as `python manage.py --settings config.settings migrate`
 - custom aliases such as `dj migrate`
 - database-aware applied/unapplied migration filtering
+
+---
+*By [Soldatov Serhii](https://github.com/soldatov-ss) · Last updated: May 2026*

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  {% if not page.url %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "django-completion",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Linux, macOS",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "url": "https://soldatov-ss.github.io/django-completion/",
+    "downloadUrl": "https://pypi.org/project/django-completion/",
+    "softwareVersion": "0.2.11",
+    "softwareRequirements": "Python 3.10+, Django 4.2+",
+    "featureList": [
+      "Completes Django management command names",
+      "Completes app labels from INSTALLED_APPS",
+      "Completes migration names per app",
+      "Completes option flags and arguments",
+      "Works in bash and zsh",
+      "Reads a local JSON cache — no Django import at completion time",
+      "Auto-refreshes cache after migrate, makemigrations, and startapp"
+    ],
+    "author": {
+      "@type": "Person",
+      "name": "Soldatov Serhii",
+      "url": "https://github.com/soldatov-ss"
+    },
+    "license": "https://opensource.org/licenses/MIT",
+    "description": "Project-aware tab completion for Django's manage.py — completes commands, app labels, options, and migration targets in bash and zsh."
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "django-completion",
+    "url": "https://soldatov-ss.github.io/django-completion/"
+  }
+  </script>
+  {% endif %}
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-completion"
-version = "0.2.10"
+version = "0.2.11"
 description = "Tab completion for Django's manage.py — commands, app labels, options, and migration targets in bash and zsh"
 readme = "README.md"
 authors = [

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -20,6 +20,19 @@ def _run(*cmd: str) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _sync_schema_version(version: str) -> None:
+    schema_path = Path("overrides/main.html")
+    if not schema_path.exists():
+        return
+    text = schema_path.read_text()
+    import re
+
+    updated = re.sub(r'"softwareVersion":\s*"[^"]*"', f'"softwareVersion": "{version}"', text)
+    if updated != text:
+        schema_path.write_text(updated)
+        print(f"Updated softwareVersion in {schema_path} to {version}")
+
+
 def _check_clean_tree() -> None:
     result = subprocess.run(["git", "status", "--porcelain"], capture_output=True, text=True, check=True)
     if result.stdout.strip():
@@ -64,6 +77,7 @@ def main() -> None:
     version = pyproject["project"]["version"]
     tag = f"v{version}"
 
+    _sync_schema_version(version)
     _check_clean_tree()
     notes = _check_changelog(version)
     _check_tests()

--- a/uv.lock
+++ b/uv.lock
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "django-completion"
-version = "0.2.10"
+version = "0.2.11"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },

--- a/zensical.toml
+++ b/zensical.toml
@@ -14,6 +14,9 @@ nav = [
   { "API Reference" = "api.md" },
 ]
 
+[project.theme]
+custom_dir = "overrides"
+
 [[project.theme.palette]]
 media = "(prefers-color-scheme: light)"
 scheme = "default"


### PR DESCRIPTION
## Summary

- Add `SoftwareApplication` + `WebSite` JSON-LD schema to docs homepage via Zensical template override (`overrides/main.html`) — improves AI search citation accuracy and disambiguates from deprecated coleifer/django-completion package
- Expand `docs/index.md` with "How it works" and "Why not Django's built-in?" sections (was navigation-only at 246 words)
- Add author attribution footer to all 7 doc pages (E-E-A-T signal)
- Add external links in `comparison.md` to Django's bash completion source and Python argparse docs
- Automate `softwareVersion` sync in `scripts/release.py` — keeps JSON-LD schema version in lock-step with `pyproject.toml` on every release
- Bump version to 0.2.11, add `CHANGELOG/0.2.11.md`

## Test plan

- [ ] `python -m zensical build` passes
- [ ] `site/index.html` contains JSON-LD with correct `softwareVersion: "0.2.11"`
- [ ] JSON-LD is absent from all subpages (comparison, installation, usage, etc.)
- [ ] Author footer visible on all 7 doc pages
- [ ] External links in comparison.md render correctly
- [ ] `scripts/release.py` dry-run: confirm `_sync_schema_version` would update the version field