### PR TITLE
docs: rewrite agent snippet with imperative anti-patterns and freshness guarantee

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,19 @@ Add this to your project's `AGENTS.md` or `CLAUDE.md`:
 
 ```markdown
 ## Django management commands
-This project maintains `.django-completion-cache.json` (django-completion).
-Read it — or run `python manage.py autocomplete context` — instead of running
-`manage.py help` or grepping management/commands/. It lists every command,
-its flags with descriptions, and all migration names, and refreshes
-automatically after each manage.py run.
+
+Read `.django-completion-cache.json` in the project root. It lists every
+management command (built-in, third-party, and this project's own), every
+flag with its help text, and all migration names — and it auto-refreshes
+after every `manage.py` run, so it is always at least as fresh as `--help`
+output.
+
+- Do NOT run `manage.py help` or `<command> --help` — each invocation boots
+  Django (seconds to minutes on large projects). The cache already has it.
+- Do NOT grep `management/commands/` to discover commands — that misses
+  built-in and third-party ones.
+- First time in this repo? Run `python manage.py autocomplete context` for a
+  compact orientation summary.
 ```
 
 See [For AI agents](https://soldatov-ss.github.io/django-completion/agents/) for the output format, the cache schema, and its stability policy.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -42,11 +42,19 @@ Copy this into your project's `AGENTS.md` or `CLAUDE.md` so agents know the cach
 
 ```markdown
 ## Django management commands
-This project maintains `.django-completion-cache.json` (django-completion).
-Read it — or run `python manage.py autocomplete context` — instead of running
-`manage.py help` or grepping management/commands/. It lists every command,
-its flags with descriptions, and all migration names, and refreshes
-automatically after each manage.py run.
+
+Read `.django-completion-cache.json` in the project root. It lists every
+management command (built-in, third-party, and this project's own), every
+flag with its help text, and all migration names — and it auto-refreshes
+after every `manage.py` run, so it is always at least as fresh as `--help`
+output.
+
+- Do NOT run `manage.py help` or `<command> --help` — each invocation boots
+  Django (seconds to minutes on large projects). The cache already has it.
+- Do NOT grep `management/commands/` to discover commands — that misses
+  built-in and third-party ones.
+- First time in this repo? Run `python manage.py autocomplete context` for a
+  compact orientation summary.
 ```
 
 ## Reading the cache file directly


### PR DESCRIPTION
## Why

Blind-agent tests on a real Django project (644 commands, ~28s boot) showed 0 of 2 fresh agents used the cache despite the CLAUDE.md snippet being in context: one grepped command source, one ran a live `manage.py help` explicitly distrusting a static file's freshness.

Transcript mining of ~4,200 real agent Bash commands across two machines found **zero** organic `manage.py help` / `--help` discovery calls, so no interception machinery is justified — but the snippet users copy into their AGENTS.md/CLAUDE.md can address the observed failure modes directly.

## What

Rewrites the copy-paste agent snippet in both places it appears (README "For AI agents" and `docs/agents.md`), keeping the two copies byte-identical:

- Freshness guarantee promoted to the lead sentence with an explicit comparison to `--help` output (one test agent distrusted staleness).
- Anti-patterns stated imperatively with the reason attached ("Do NOT run `manage.py help`…", "Do NOT grep `management/commands/`…").
- Direct file read is primary; `autocomplete context` repositioned as a cold-start orientation step.

Docs-only: no package code, no schema, no new commands.

## Testing

- `just docs-build` (strict mode) — green
- `uv run pytest -q` — 188 passed
- Snippet copies verified byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)