### PR TITLE
refactor: single-source cache filename via template render step (v0.3.1 prep)

### DIFF
--- a/CHANGELOG/0.3.1.md
+++ b/CHANGELOG/0.3.1.md
@@ -1,0 +1,11 @@
+# 0.3.1
+
+Fixes the agent-facing guidance based on blind-agent testing on a real project, and makes the completion-script render step real. Tab completion behavior is unchanged.
+
+## Fixed
+
+- **Agent snippet rewritten** (README and docs): blind tests on a real Django project showed fresh agents ignoring the cache despite the snippet being in context — one grepped command source, one ran a live `manage.py help` because it distrusted a static file's freshness. The new snippet leads with the freshness guarantee (the cache auto-refreshes after every `manage.py` run, so it is always at least as fresh as `--help` output) and states the anti-patterns imperatively with the reason attached.
+
+## Internal
+
+- **Cache filename is single-sourced**: the shell script templates and the uninstall message now render `.django-completion-cache.json` from the `CACHE_FILENAME` constant instead of hardcoding it in four places. Rendered scripts are byte-identical to before — existing installs keep working without reinstalling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-completion"
-version = "0.3.0"
+version = "0.3.1"
 description = "Django manage.py context for coding agents + project-aware tab completion — commands, flags, app labels, and migration targets from one cache"
 readme = "README.md"
 authors = [

--- a/src/django_completion/management/commands/autocomplete.py
+++ b/src/django_completion/management/commands/autocomplete.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, cast
 
 from django.core.management.base import BaseCommand
 
-from django_completion.cache import sane_generated_at
+from django_completion.cache import CACHE_FILENAME, sane_generated_at
 
 _INSTALL_DIR = Path.home() / ".local" / "share" / "django-completion"
 _MARKER_BEGIN = "# django-completion begin"
@@ -51,9 +51,9 @@ def _detect_shell() -> Literal["zsh", "bash"]:
 
 
 def _script_content(shell: Literal["bash", "zsh"]) -> str:
-    """Read the completion script template for the given shell."""
+    """Read the completion script template for the given shell and render it."""
     tmpl = Path(__file__).parent.parent.parent / "scripts" / _TMPL_NAMES[shell]
-    return tmpl.read_text()
+    return tmpl.read_text().replace("{{CACHE_FILENAME}}", CACHE_FILENAME)
 
 
 def _package_version() -> str:
@@ -620,4 +620,4 @@ class Command(BaseCommand):
             for rc_path in removed_rc_paths:
                 self.stdout.write(f"  source {rc_path}")
             self.stdout.write("Or open a new terminal.")
-        self.stdout.write("\nNote: .django-completion-cache.json was left in place. Delete it manually if needed.")
+        self.stdout.write(f"\nNote: {CACHE_FILENAME} was left in place. Delete it manually if needed.")

--- a/src/django_completion/scripts/bash_completion.sh.tmpl
+++ b/src/django_completion/scripts/bash_completion.sh.tmpl
@@ -7,8 +7,8 @@
 _django_manage_find_cache() {
     local dir="$PWD"
     while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/.django-completion-cache.json" ]]; then
-            echo "$dir/.django-completion-cache.json"
+        if [[ -f "$dir/{{CACHE_FILENAME}}" ]]; then
+            echo "$dir/{{CACHE_FILENAME}}"
             return
         fi
         dir="$(dirname "$dir")"

--- a/src/django_completion/scripts/zsh_completion.zsh.tmpl
+++ b/src/django_completion/scripts/zsh_completion.zsh.tmpl
@@ -7,7 +7,7 @@
 _django_manage_find_cache() {
     local dir="$PWD"
     while [[ "$dir" != "/" ]]; do
-        [[ -f "$dir/.django-completion-cache.json" ]] && { echo "$dir/.django-completion-cache.json"; return; }
+        [[ -f "$dir/{{CACHE_FILENAME}}" ]] && { echo "$dir/{{CACHE_FILENAME}}"; return; }
         dir="$(dirname "$dir")"
     done
 }

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,16 +1,29 @@
 """Subprocess-based shell completion tests (Step 8)."""
 
+from functools import lru_cache
 import io
 import json
 from pathlib import Path
 import shutil
 import subprocess
+import tempfile
+from typing import Literal
 
 import pytest
 
 SCRIPTS_DIR = Path(__file__).parent.parent / "src/django_completion/scripts"
 BASH_SCRIPT = SCRIPTS_DIR / "bash_completion.sh.tmpl"
 ZSH_SCRIPT = SCRIPTS_DIR / "zsh_completion.zsh.tmpl"
+
+
+@lru_cache(maxsize=None)
+def _rendered_script(shell: Literal["bash", "zsh"]) -> Path:
+    """Write the rendered completion script (what `install` ships) to a temp file."""
+    from django_completion.management.commands.autocomplete import _script_content
+
+    path = Path(tempfile.mkdtemp()) / f"completion.{shell}"
+    path.write_text(_script_content(shell))
+    return path
 
 
 @pytest.fixture
@@ -59,7 +72,7 @@ def _bash_complete(
             "bash",
             "-c",
             f"""
-source {BASH_SCRIPT}
+source {_rendered_script("bash")}
 cd {cache_dir}
 COMP_WORDS=({words_str})
 COMP_CWORD={comp_cword}
@@ -215,7 +228,7 @@ def test_bash_empty_completions_do_not_leak_filenames(cache_dir):
 @pytest.mark.skipif(not shutil.which("zsh"), reason="zsh not available")
 def test_zsh_script_sources_without_error(cache_dir):
     result = subprocess.run(
-        ["zsh", "-c", f"source {ZSH_SCRIPT}; echo OK"],
+        ["zsh", "-c", f"source {_rendered_script('zsh')}; echo OK"],
         capture_output=True,
         text=True,
         timeout=10,
@@ -244,6 +257,15 @@ def test_zsh_helper_is_invoked():
     assert "django_completion._complete" in text
     assert "python3 -m django_completion._complete" in text
     assert "compdef _django_python_manage python python3 uv" in text
+
+
+def test_rendered_script_substitutes_cache_filename():
+    from django_completion.cache import CACHE_FILENAME
+
+    for shell in ("bash", "zsh"):
+        text = _rendered_script(shell).read_text()
+        assert CACHE_FILENAME in text
+        assert "{{" not in text
 
 
 # ── Full integration: refresh command writes a valid cache ──────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -171,9 +171,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version < '3.12'" },
-    { name = "sqlparse", marker = "python_full_version < '3.12'" },
-    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
 wheels = [
@@ -188,9 +188,9 @@ resolution-markers = [
     "python_full_version >= '3.12'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version >= '3.12'" },
-    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
-    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/b9/4155091ad1788b38563bd77a7258c0834e8c12a7f56f6975deaf54f8b61d/django-6.0.4.tar.gz", hash = "sha256:8cfa2572b3f2768b2e84983cf3c4811877a01edb64e817986ec5d60751c113ac", size = 10907407, upload-time = "2026-04-07T13:55:44.961Z" }
 wheels = [
@@ -199,7 +199,7 @@ wheels = [
 
 [[package]]
 name = "django-completion"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.13", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -267,7 +267,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [


### PR DESCRIPTION
## Why

ARCH review candidate 3 (`tmp/ARCHITECTURE_REVIEW.md`): `.django-completion-cache.json` was hardcoded in four places — the `CACHE_FILENAME` constant in `cache.py`, both shell templates, and the uninstall message. The `.tmpl` files were copied verbatim; no render step existed despite the suffix.

## What

- Templates use a `{{CACHE_FILENAME}}` placeholder; `_script_content()` renders it from `CACHE_FILENAME` (single source of truth).
- Uninstall message builds from the same constant.
- E2e subprocess tests now source the **rendered** scripts — exactly what `install` writes to disk — instead of raw templates; raw-template content assertions unchanged.
- New unit test: rendered output contains the real filename, no leftover placeholders.
- Version bump to 0.3.1 + `CHANGELOG/0.3.1.md` (covers this and the agent snippet rewrite in #37), so `just release` is ready once both PRs merge.

**Deliberately skipped:** substituting the `python3 -m django_completion._complete` invocation — each template has it once in dialect-specific code; a placeholder dedups nothing.

## Migration risk

None. Rendered output verified **byte-identical** to the previous template content for both shells (diffed against `main`), so already-installed scripts are content-identical and need no reinstall.

## Testing

- `uv run pytest -q` — 189 passed (188 + 1 new)
- `uv run ruff check .` / `uv run ty check` — clean
- Rendered-vs-main byte-identity check for both shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)